### PR TITLE
fix: json_decode check to ensure value is a string before decoding

### DIFF
--- a/plugins/webkul/chatter/src/Traits/HasLogActivity.php
+++ b/plugins/webkul/chatter/src/Traits/HasLogActivity.php
@@ -312,10 +312,10 @@ trait HasLogActivity
         }
 
         if (
-            ! is_array($value)
-            && json_decode($value, true)
+            is_string($value)
+            && $decoded = json_decode($value, true)
         ) {
-            $value = json_decode($value, true);
+            $value = $decoded;
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
This pull request includes a minor update to the `formatAttributeValue` method in the `HasLogActivity` trait. The change optimizes the handling of JSON-decoded values by introducing a variable assignment to avoid redundant decoding.

Optimization in JSON decoding:

* [`plugins/webkul/chatter/src/Traits/HasLogActivity.php`](diffhunk://#diff-7db55ffb460d4757ffeb86a5cd0b785d8533f82166db27ebf383490139f38da2L315-R318): Updated the condition to check if `$value` is a string before decoding it and assigned the decoded result to `$decoded`, reducing redundant calls to `json_decode`.