### PR TITLE
Issue #514 has been fixed.

### DIFF
--- a/plugins/webkul/blogs/resources/lang/en/filament/admin/clusters/configurations/resources/category/pages/manage-categories.php
+++ b/plugins/webkul/blogs/resources/lang/en/filament/admin/clusters/configurations/resources/category/pages/manage-categories.php
@@ -11,4 +11,9 @@ return [
             ],
         ],
     ],
+
+    'tabs' => [
+        'all'      => 'All',
+        'archived' => 'Archived',
+    ],
 ];

--- a/plugins/webkul/blogs/src/Filament/Admin/Clusters/Configurations/Resources/CategoryResource/Pages/ManageCategories.php
+++ b/plugins/webkul/blogs/src/Filament/Admin/Clusters/Configurations/Resources/CategoryResource/Pages/ManageCategories.php
@@ -4,9 +4,11 @@ namespace Webkul\Blog\Filament\Admin\Clusters\Configurations\Resources\CategoryR
 
 use Filament\Actions;
 use Filament\Notifications\Notification;
+use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ManageRecords;
 use Illuminate\Support\Facades\Auth;
 use Webkul\Blog\Filament\Admin\Clusters\Configurations\Resources\CategoryResource;
+use Webkul\Blog\Models\Category;
 
 class ManageCategories extends ManageRecords
 {
@@ -29,6 +31,17 @@ class ManageCategories extends ManageRecords
                         ->title(__('blogs::filament/admin/clusters/configurations/resources/category/pages/manage-categories.header-actions.create.notification.title'))
                         ->body(__('blogs::filament/admin/clusters/configurations/resources/category/pages/manage-categories.header-actions.create.notification.body')),
                 ),
+        ];
+    }
+
+    public function getTabs(): array
+    {
+        return [
+            'all' => Tab::make(__('blogs::filament/admin/clusters/configurations/resources/category/pages/manage-categories.tabs.all'))
+                ->badge(Category::count()),
+            'archived' => Tab::make(__('blogs::filament/admin/clusters/configurations/resources/category/pages/manage-categories.tabs.archived'))
+                ->badge(Category::onlyTrashed()->count())
+                ->modifyQueryUsing(fn ($query) => $query->onlyTrashed()),
         ];
     }
 }


### PR DESCRIPTION
Hello @harshqa-webkul,

This #514 issue is not a bug. When a category is deleted, the system performs a soft delete — meaning the record is not permanently removed. So, when creating a new category with the same slug, it conflicts with the existing (soft-deleted) record.

The system behaves as expected. I've implemented a tabbed UI to allow navigation between "All" and "Archived" categories, which makes this behavior clearer.

Thanks!