### PR TITLE
Improve Page Navigation Layout for Clustered and Record Views

### DIFF
--- a/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/CreateBill.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/CreateBill.php
@@ -13,6 +13,15 @@ class CreateBill extends CreateRecord
 {
     use HasRepeaterColumnManager;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = BillResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/EditBill.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/EditBill.php
@@ -12,10 +12,11 @@ use Webkul\Account\Filament\Resources\BillResource\Actions\CreditNoteAction;
 use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditBill extends EditRecord
 {
-    use HasRepeaterColumnManager;
+    use HasRecordNavigationTabs, HasRepeaterColumnManager;
 
     protected static string $resource = BillResource::class;
 

--- a/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/ViewBill.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/BillResource/Pages/ViewBill.php
@@ -9,9 +9,12 @@ use Webkul\Account\Filament\Resources\BillResource;
 use Webkul\Account\Filament\Resources\BillResource\Actions\CreditNoteAction;
 use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewBill extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = BillResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
@@ -13,6 +13,15 @@ class CreateInvoice extends CreateRecord
 {
     use HasRepeaterColumnManager;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = InvoiceResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
@@ -12,10 +12,11 @@ use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Partner\Models\Partner;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditInvoice extends EditRecord
 {
-    use HasRepeaterColumnManager;
+    use HasRecordNavigationTabs, HasRepeaterColumnManager;
 
     protected static string $resource = InvoiceResource::class;
 

--- a/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
@@ -8,9 +8,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Webkul\Account\Filament\Resources\InvoiceResource;
 use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewInvoice extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = InvoiceResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/CreatePayments.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/CreatePayments.php
@@ -10,6 +10,15 @@ use Webkul\Account\Filament\Resources\PaymentsResource;
 
 class CreatePayments extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = PaymentsResource::class;
 
     protected function getRedirectUrl(): string
@@ -28,7 +37,7 @@ class CreatePayments extends CreateRecord
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['state'] = PaymentStatus::DRAFT->value;
-        $data['created_by'] = Auth::user()->id;
+        $data['creator_id'] = Auth::user()->id;
 
         return $data;
     }

--- a/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/EditPayments.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/EditPayments.php
@@ -9,9 +9,12 @@ use Filament\Resources\Pages\EditRecord;
 use Webkul\Account\Filament\Resources\PaymentsResource;
 use Webkul\Account\Filament\Resources\PaymentsResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditPayments extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PaymentsResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/ViewPayments.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/PaymentsResource/Pages/ViewPayments.php
@@ -9,9 +9,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Webkul\Account\Filament\Resources\PaymentsResource;
 use Webkul\Account\Filament\Resources\PaymentsResource\Actions as BaseActions;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewPayments extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PaymentsResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/accounts/src/Filament/Resources/RefundResource/Pages/EditRefund.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/RefundResource/Pages/EditRefund.php
@@ -10,9 +10,12 @@ use Webkul\Account\Facades\Account;
 use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Account\Filament\Resources\RefundResource;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditRefund extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = RefundResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/accounts/src/Filament/Resources/RefundResource/Pages/ViewRefund.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/RefundResource/Pages/ViewRefund.php
@@ -7,9 +7,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Webkul\Account\Filament\Resources\InvoiceResource\Actions as BaseActions;
 use Webkul\Account\Filament\Resources\RefundResource;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewRefund extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = RefundResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource.php
@@ -8,7 +8,6 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -38,8 +37,6 @@ class DeliveryResource extends Resource
     protected static ?int $navigationSort = 3;
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/CreateDelivery.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/CreateDelivery.php
@@ -13,6 +13,15 @@ use Webkul\Inventory\Models\OperationType;
 
 class CreateDelivery extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = DeliveryResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/EditDelivery.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/EditDelivery.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\DeliveryResource;
 use Webkul\Inventory\Models\Delivery;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditDelivery extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = DeliveryResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/ViewDelivery.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DeliveryResource/Pages/ViewDelivery.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\DeliveryResource;
 use Webkul\Inventory\Models\Delivery;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewDelivery extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = DeliveryResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource.php
@@ -8,7 +8,6 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -39,8 +38,6 @@ class DropshipResource extends Resource
     protected static ?string $recordTitleAttribute = 'name';
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function isDiscovered(): bool
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/CreateDropship.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/CreateDropship.php
@@ -13,6 +13,15 @@ use Webkul\Inventory\Models\OperationType;
 
 class CreateDropship extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = DropshipResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/EditDropship.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/EditDropship.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\DropshipResource;
 use Webkul\Inventory\Models\Dropship;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditDropship extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = DropshipResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/ViewDropship.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/DropshipResource/Pages/ViewDropship.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\DropshipResource;
 use Webkul\Inventory\Models\Dropship;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewDropship extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = DropshipResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource.php
@@ -8,7 +8,6 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -39,8 +38,6 @@ class InternalResource extends Resource
     protected static ?int $navigationSort = 3;
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function isDiscovered(): bool
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/CreateInternal.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/CreateInternal.php
@@ -15,6 +15,15 @@ class CreateInternal extends CreateRecord
 {
     protected static string $resource = InternalResource::class;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     public function getTitle(): string|Htmlable
     {
         return __('inventories::filament/clusters/operations/resources/internal/pages/create-internal.title');

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/EditInternal.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/EditInternal.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\InternalResource;
 use Webkul\Inventory\Models\InternalTransfer;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditInternal extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = InternalResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/ViewInternal.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/InternalResource/Pages/ViewInternal.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\InternalResource;
 use Webkul\Inventory\Models\InternalTransfer;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewInternal extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = InternalResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/OperationResource/Pages/ManageMoves.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/OperationResource/Pages/ManageMoves.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\MoveState;
 use Webkul\Inventory\Enums\ProductTracking;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\OperationResource;
 use Webkul\Inventory\Models\MoveLine;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageMoves extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = OperationResource::class;
 
     protected static string $relationship = 'moveLines';

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/QuantityResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/QuantityResource.php
@@ -8,7 +8,6 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
@@ -50,8 +49,6 @@ class QuantityResource extends Resource
     protected static ?int $navigationSort = 4;
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationLabel(): string
     {
@@ -529,22 +526,22 @@ class QuantityResource extends Resource
             });
     }
 
-    static public function getOperationSettings(): OperationSettings
+    public static function getOperationSettings(): OperationSettings
     {
         return once(fn () => app(OperationSettings::class));
     }
 
-    static public function getProductSettings(): ProductSettings
+    public static function getProductSettings(): ProductSettings
     {
         return once(fn () => app(ProductSettings::class));
     }
 
-    static public function getTraceabilitySettings(): TraceabilitySettings
+    public static function getTraceabilitySettings(): TraceabilitySettings
     {
         return once(fn () => app(TraceabilitySettings::class));
     }
 
-    static public function getWarehouseSettings(): WarehouseSettings
+    public static function getWarehouseSettings(): WarehouseSettings
     {
         return once(fn () => app(WarehouseSettings::class));
     }

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource.php
@@ -8,7 +8,6 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -38,8 +37,6 @@ class ReceiptResource extends Resource
     protected static ?string $recordTitleAttribute = 'name';
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/CreateReceipt.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/CreateReceipt.php
@@ -16,6 +16,15 @@ class CreateReceipt extends CreateRecord
 {
     use HasRepeaterColumnManager;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = ReceiptResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/EditReceipt.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/EditReceipt.php
@@ -13,10 +13,11 @@ use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\ReceiptResource;
 use Webkul\Inventory\Models\Receipt;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditReceipt extends EditRecord
 {
-    use HasRepeaterColumnManager;
+    use HasRecordNavigationTabs, HasRepeaterColumnManager;
 
     protected static string $resource = ReceiptResource::class;
 

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/ViewReceipt.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ReceiptResource/Pages/ViewReceipt.php
@@ -12,9 +12,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Actions as OperationActions;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\ReceiptResource;
 use Webkul\Inventory\Models\Receipt;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewReceipt extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ReceiptResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ScrapResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ScrapResource.php
@@ -13,7 +13,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Group;
@@ -69,8 +68,6 @@ class ScrapResource extends Resource
     protected static ?int $navigationSort = 5;
 
     protected static ?string $cluster = Operations::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationLabel(): string
     {
@@ -610,22 +607,22 @@ class ScrapResource extends Resource
             ->columns(3);
     }
 
-    static public function getOperationSettings(): OperationSettings
+    public static function getOperationSettings(): OperationSettings
     {
         return once(fn () => app(OperationSettings::class));
     }
 
-    static public function getProductSettings(): ProductSettings
+    public static function getProductSettings(): ProductSettings
     {
         return once(fn () => app(ProductSettings::class));
     }
 
-    static public function getTraceabilitySettings(): TraceabilitySettings
+    public static function getTraceabilitySettings(): TraceabilitySettings
     {
         return once(fn () => app(TraceabilitySettings::class));
     }
 
-    static public function getWarehouseSettings(): WarehouseSettings
+    public static function getWarehouseSettings(): WarehouseSettings
     {
         return once(fn () => app(WarehouseSettings::class));
     }

--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ScrapResource/Pages/CreateScrap.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/ScrapResource/Pages/CreateScrap.php
@@ -13,6 +13,15 @@ use Webkul\Inventory\Models\Warehouse;
 
 class CreateScrap extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = ScrapResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource.php
@@ -15,7 +15,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
@@ -60,8 +59,6 @@ class LotResource extends Resource
     protected static ?string $recordTitleAttribute = 'name';
 
     protected static ?int $navigationSort = 3;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function isDiscovered(): bool
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/CreateLot.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/CreateLot.php
@@ -7,5 +7,14 @@ use Webkul\Inventory\Filament\Clusters\Products\Resources\LotResource;
 
 class CreateLot extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = LotResource::class;
 }

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/EditLot.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/EditLot.php
@@ -10,9 +10,12 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\QueryException;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\LotResource;
 use Webkul\Inventory\Models\Lot;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditLot extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = LotResource::class;
 
     protected function getSavedNotification(): Notification

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/ManageQuantities.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/ManageQuantities.php
@@ -18,9 +18,12 @@ use Webkul\Inventory\Models\ProductQuantity;
 use Webkul\Inventory\Settings\OperationSettings;
 use Webkul\Inventory\Settings\TraceabilitySettings;
 use Webkul\Inventory\Settings\WarehouseSettings;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageQuantities extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = LotResource::class;
 
     protected static string $relationship = 'quantities';

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/ViewLot.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/LotResource/Pages/ViewLot.php
@@ -10,9 +10,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Database\QueryException;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\LotResource;
 use Webkul\Inventory\Models\Lot;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewLot extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = LotResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource.php
@@ -15,7 +15,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
@@ -54,8 +53,6 @@ class PackageResource extends Resource
     protected static ?string $recordTitleAttribute = 'name';
 
     protected static ?int $navigationSort = 2;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function isDiscovered(): bool
     {

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/CreatePackage.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/CreatePackage.php
@@ -9,6 +9,15 @@ use Webkul\Inventory\Filament\Clusters\Products\Resources\PackageResource;
 
 class CreatePackage extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = PackageResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/EditPackage.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/EditPackage.php
@@ -11,9 +11,12 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\QueryException;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\PackageResource;
 use Webkul\Inventory\Models\Package;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditPackage extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PackageResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ManageOperations.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ManageOperations.php
@@ -13,10 +13,12 @@ use Webkul\Inventory\Enums\OperationState;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\OperationResource;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\PackageResource;
 use Webkul\Inventory\Models\Operation;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TableViews\Filament\Concerns\HasTableViews;
 
 class ManageOperations extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
     use HasTableViews;
 
     protected static string $resource = PackageResource::class;

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ManageProducts.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ManageProducts.php
@@ -6,9 +6,12 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\PackageResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageProducts extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PackageResource::class;
 
     protected static string $relationship = 'quantities';

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ViewPackage.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/PackageResource/Pages/ViewPackage.php
@@ -11,9 +11,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Database\QueryException;
 use Webkul\Inventory\Filament\Clusters\Products\Resources\PackageResource;
 use Webkul\Inventory\Models\Package;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewPackage extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PackageResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource.php
@@ -8,7 +8,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
@@ -49,8 +48,6 @@ class ProductResource extends BaseProductResource
     protected static ?string $cluster = Products::class;
 
     protected static ?int $navigationSort = 1;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static ?string $recordTitleAttribute = 'name';
 

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ManageMoves.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ManageMoves.php
@@ -16,11 +16,13 @@ use Webkul\Inventory\Filament\Clusters\Products\Resources\ProductResource;
 use Webkul\Inventory\Settings\OperationSettings;
 use Webkul\Inventory\Settings\TraceabilitySettings;
 use Webkul\Inventory\Settings\WarehouseSettings;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TableViews\Filament\Components\PresetView;
 use Webkul\TableViews\Filament\Concerns\HasTableViews;
 
 class ManageMoves extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
     use HasTableViews;
 
     protected static string $resource = ProductResource::class;

--- a/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ManageQuantities.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ManageQuantities.php
@@ -29,12 +29,13 @@ use Webkul\Inventory\Models\Warehouse;
 use Webkul\Inventory\Settings\OperationSettings;
 use Webkul\Inventory\Settings\TraceabilitySettings;
 use Webkul\Inventory\Settings\WarehouseSettings;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TableViews\Filament\Components\PresetView;
 use Webkul\TableViews\Filament\Concerns\HasTableViews;
 
 class ManageQuantities extends ManageRelatedRecords
 {
-    use HasTableViews;
+    use HasRecordNavigationTabs, HasTableViews;
 
     protected static string $resource = ProductResource::class;
 

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Account\Filament\Resources\CreditNoteResource as BaseCreditNoteResource;
 use Webkul\Invoice\Filament\Clusters\Customer;
@@ -21,8 +20,6 @@ class CreditNotesResource extends BaseCreditNoteResource
     protected static ?string $cluster = Customer::class;
 
     protected static ?int $navigationSort = 2;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource/Pages/EditCreditNotes.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource/Pages/EditCreditNotes.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources\CreditNotesResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\CreditNoteResource\Pages\EditCreditNote as BaseCreditNote;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\CreditNotesResource;
 
 class EditCreditNotes extends BaseCreditNote
 {
     protected static string $resource = CreditNotesResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource/Pages/ViewCreditNote.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/CreditNotesResource/Pages/ViewCreditNote.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources\CreditNotesResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\CreditNoteResource\Pages\ViewCreditNote as BaseViewInvoice;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\CreditNotesResource;
 
 class ViewCreditNote extends BaseViewInvoice
 {
     protected static string $resource = CreditNotesResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Account\Filament\Resources\InvoiceResource as BaseInvoiceResource;
 use Webkul\Invoice\Filament\Clusters\Customer;
@@ -21,8 +20,6 @@ class InvoiceResource extends BaseInvoiceResource
     protected static ?string $cluster = Customer::class;
 
     protected static ?int $navigationSort = 1;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource/Pages/EditInvoice.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource/Pages/EditInvoice.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources\InvoiceResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\InvoiceResource\Pages\EditInvoice as BaseEditInvoice;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\InvoiceResource;
 
 class EditInvoice extends BaseEditInvoice
 {
     protected static string $resource = InvoiceResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource/Pages/ViewInvoice.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/InvoiceResource/Pages/ViewInvoice.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources\InvoiceResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\InvoiceResource\Pages\ViewInvoice as BaseViewInvoice;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\InvoiceResource;
 
 class ViewInvoice extends BaseViewInvoice
 {
     protected static string $resource = InvoiceResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PartnerResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PartnerResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Tables\Table;
 use Webkul\Invoice\Filament\Clusters\Customer;
@@ -28,8 +27,6 @@ class PartnerResource extends BasePartnerResource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-users';
 
     protected static ?string $cluster = Customer::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PaymentsResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PaymentsResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\PaymentsResource as BasePaymentsResource;
 use Webkul\Invoice\Filament\Clusters\Customer;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\PaymentsResource\Pages\CreatePayments;
@@ -20,8 +19,6 @@ class PaymentsResource extends BasePaymentsResource
     protected static ?int $navigationSort = 4;
 
     protected static ?string $cluster = Customer::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PaymentsResource/Pages/CreatePayments.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/PaymentsResource/Pages/CreatePayments.php
@@ -9,6 +9,15 @@ class CreatePayments extends BaseCreatePayments
 {
     protected static string $resource = PaymentsResource::class;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data = parent::mutateFormDataBeforeCreate($data);

--- a/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/ProductResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Customer/Resources/ProductResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Customer\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Invoice\Filament\Clusters\Customer;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\ProductResource\Pages\CreateProduct;
@@ -19,8 +18,6 @@ class ProductResource extends BaseProductResource
     protected static ?string $model = Product::class;
 
     protected static ?string $cluster = Customer::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static bool $shouldRegisterNavigation = true;
 

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Account\Filament\Resources\BillResource as BaseBillResource;
 use Webkul\Invoice\Filament\Clusters\Vendors;
@@ -23,8 +22,6 @@ class BillResource extends BaseBillResource
     protected static ?int $navigationSort = 1;
 
     protected static ?string $cluster = Vendors::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationGroup(): ?string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource/Pages/EditBill.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource/Pages/EditBill.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\BillResource\Pages\EditBill as BaseEditBill;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource;
 
 class EditBill extends BaseEditBill
 {
     protected static string $resource = BillResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource/Pages/ViewBill.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/BillResource/Pages/ViewBill.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\BillResource\Pages\ViewBill as BaseViewBill;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource;
 
 class ViewBill extends BaseViewBill
 {
     protected static string $resource = BillResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/PaymentsResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/PaymentsResource.php
@@ -2,10 +2,8 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Infolists\Infolist;
+use Filament\Schemas\Schema;
 use Webkul\Account\Filament\Resources\PaymentsResource as BasePaymentsResource;
 use Webkul\Invoice\Filament\Clusters\Vendors;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\PaymentsResource\Pages\CreatePayments;
@@ -13,7 +11,6 @@ use Webkul\Invoice\Filament\Clusters\Vendors\Resources\PaymentsResource\Pages\Ed
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\PaymentsResource\Pages\ListPayments;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\PaymentsResource\Pages\ViewPayments;
 use Webkul\Invoice\Models\Payment;
-use Filament\Schemas\Schema;
 
 class PaymentsResource extends BasePaymentsResource
 {
@@ -24,8 +21,6 @@ class PaymentsResource extends BasePaymentsResource
     protected static ?int $navigationSort = 3;
 
     protected static ?string $cluster = Vendors::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource.php
@@ -5,7 +5,6 @@ namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
@@ -38,8 +37,6 @@ class ProductResource extends BaseProductResource
     protected static ?int $navigationSort = 5;
 
     protected static ?string $cluster = Vendors::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/CreateProduct.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/CreateProduct.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\CreateProduct as BaseCreateProduct;
 
 class CreateProduct extends BaseCreateProduct
 {
     protected static string $resource = ProductResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/EditProduct.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/EditProduct.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\EditProduct as BaseEditProduct;
 
 class EditProduct extends BaseEditProduct
 {
     protected static string $resource = ProductResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ManageAttributes.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ManageAttributes.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\ManageAttributes as BaseManageAttributes;
 
@@ -13,9 +12,4 @@ class ManageAttributes extends BaseManageAttributes
     protected static string $relationship = 'attributes';
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-swatch';
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ManageVariants.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ManageVariants.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\ManageVariants as BaseManageVariants;
 
 class ManageVariants extends BaseManageVariants
 {
     protected static string $resource = ProductResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ViewProduct.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/ProductResource/Pages/ViewProduct.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\ViewProduct as BaseViewProduct;
 
 class ViewProduct extends BaseViewProduct
 {
     protected static string $resource = ProductResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Account\Filament\Resources\RefundResource as BaseRefundResource;
 use Webkul\Invoice\Filament\Clusters\Vendors;
@@ -21,8 +20,6 @@ class RefundResource extends BaseRefundResource
     protected static bool $shouldRegisterNavigation = true;
 
     protected static ?string $cluster = Vendors::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationGroup(): ?string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource/Pages/EditRefund.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource/Pages/EditRefund.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\RefundResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\RefundResource\Pages\EditRefund as BaseEditRefund;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\RefundResource;
 
 class EditRefund extends BaseEditRefund
 {
     protected static string $resource = RefundResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource/Pages/ViewRefund.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/RefundResource/Pages/ViewRefund.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Invoice\Filament\Clusters\Vendors\Resources\RefundResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Account\Filament\Resources\RefundResource\Pages\ViewRefund as BaseViewRefund;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\RefundResource;
 
 class ViewRefund extends BaseViewRefund
 {
     protected static string $resource = RefundResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/VendorResource.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/VendorResource.php
@@ -9,7 +9,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Schemas\Components\Fieldset;
@@ -47,8 +46,6 @@ class VendorResource extends BaseVendorResource
     protected static ?int $navigationSort = 4;
 
     protected static ?string $cluster = Vendors::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/VendorResource/Pages/ManageBankAccounts.php
+++ b/plugins/webkul/invoices/src/Filament/Clusters/Vendors/Resources/VendorResource/Pages/ManageBankAccounts.php
@@ -8,9 +8,12 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Table;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\VendorResource;
 use Webkul\Partner\Filament\Resources\BankAccountResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageBankAccounts extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = VendorResource::class;
 
     protected static string $relationship = 'bankAccounts';

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/CreatePartner.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/CreatePartner.php
@@ -9,6 +9,15 @@ use Webkul\Partner\Filament\Resources\PartnerResource;
 
 class CreatePartner extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = PartnerResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/EditPartner.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/EditPartner.php
@@ -9,9 +9,12 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Contracts\Support\Htmlable;
 use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Partner\Filament\Resources\PartnerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditPartner extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PartnerResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ManageAddresses.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ManageAddresses.php
@@ -7,9 +7,12 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Table;
 use Webkul\Partner\Filament\Resources\AddressResource;
 use Webkul\Partner\Filament\Resources\PartnerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageAddresses extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PartnerResource::class;
 
     protected static string $relationship = 'addresses';

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ManageContacts.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ManageContacts.php
@@ -9,9 +9,12 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Auth;
 use Webkul\Partner\Filament\Resources\PartnerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageContacts extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PartnerResource::class;
 
     protected static string $relationship = 'contacts';

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ViewPartner.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ViewPartner.php
@@ -9,9 +9,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\Support\Htmlable;
 use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Partner\Filament\Resources\PartnerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewPartner extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PartnerResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -16,6 +16,15 @@ class CreateProduct extends CreateRecord
         return $this->getResource()::getUrl('view', ['record' => $this->getRecord()]);
     }
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected function getCreatedNotification(): Notification
     {
         return Notification::make()

--- a/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -8,19 +8,16 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\EditRecord;
 use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Product\Filament\Resources\ProductResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditProduct extends EditRecord
 {
-    protected static string $resource = ProductResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = ProductResource::class;
 
     protected function getRedirectUrl(): string
     {

--- a/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ManageAttributes.php
+++ b/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ManageAttributes.php
@@ -7,7 +7,6 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
@@ -20,17 +19,15 @@ use Webkul\Product\Filament\Resources\AttributeResource;
 use Webkul\Product\Filament\Resources\ProductResource;
 use Webkul\Product\Filament\Resources\ProductResource\Actions\GenerateVariantsAction;
 use Webkul\Product\Models\ProductAttribute;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageAttributes extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ProductResource::class;
 
     protected static string $relationship = 'attributes';
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-swatch';
 

--- a/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ManageVariants.php
+++ b/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ManageVariants.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Product\Filament\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
@@ -10,17 +9,15 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Arr;
 use Webkul\Product\Filament\Resources\ProductResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageVariants extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ProductResource::class;
 
     protected static string $relationship = 'variants';
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
 

--- a/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ViewProduct.php
+++ b/plugins/webkul/products/src/Filament/Resources/ProductResource/Pages/ViewProduct.php
@@ -8,19 +8,16 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\ViewRecord;
 use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Product\Filament\Resources\ProductResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewProduct extends ViewRecord
 {
-    protected static string $resource = ProductResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = ProductResource::class;
 
     protected function getHeaderActions(): array
     {

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/CreateOrder.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/CreateOrder.php
@@ -14,6 +14,15 @@ class CreateOrder extends CreateRecord
 {
     use HasRepeaterColumnManager;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = OrderResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/EditOrder.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/EditOrder.php
@@ -14,10 +14,11 @@ use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\OrderResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\OrderResource\Actions as OrderActions;
 use Webkul\Purchase\Models\Order;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditOrder extends EditRecord
 {
-    use HasRepeaterColumnManager;
+    use HasRecordNavigationTabs, HasRepeaterColumnManager;
 
     protected static string $resource = OrderResource::class;
 

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ManageBills.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ManageBills.php
@@ -9,9 +9,12 @@ use Filament\Tables\Table;
 use Livewire\Livewire;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\OrderResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageBills extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = OrderResource::class;
 
     protected static string $relationship = 'accountMoves';

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ManageReceipts.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ManageReceipts.php
@@ -10,9 +10,12 @@ use Livewire\Livewire;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\OperationResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\OrderResource;
 use Webkul\Support\Package;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageReceipts extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = OrderResource::class;
 
     protected static string $relationship = 'operations';

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ViewOrder.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/OrderResource/Pages/ViewOrder.php
@@ -11,9 +11,12 @@ use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Purchase\Enums\OrderState;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\OrderResource;
 use Webkul\Purchase\Models\Order;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewOrder extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = OrderResource::class;
 
     protected function configureAction(Action $action): void

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource.php
@@ -20,7 +20,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
@@ -75,8 +74,6 @@ class PurchaseAgreementResource extends Resource
     protected static ?string $cluster = Orders::class;
 
     protected static ?int $navigationSort = 3;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static ?string $recordTitleAttribute = 'name';
 
@@ -633,12 +630,12 @@ class PurchaseAgreementResource extends Resource
             ->columns(1);
     }
 
-    static public function getOrderSettings(): OrderSettings
+    public static function getOrderSettings(): OrderSettings
     {
         return once(fn () => app(OrderSettings::class));
     }
 
-    static public function getProductSettings(): ProductSettings
+    public static function getProductSettings(): ProductSettings
     {
         return once(fn () => app(ProductSettings::class));
     }

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/CreatePurchaseAgreement.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/CreatePurchaseAgreement.php
@@ -13,7 +13,16 @@ use Webkul\Support\Concerns\HasRepeaterColumnManager;
 class CreatePurchaseAgreement extends CreateRecord
 {
     use HasRepeaterColumnManager;
-    
+
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = PurchaseAgreementResource::class;
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/EditPurchaseAgreement.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/EditPurchaseAgreement.php
@@ -12,9 +12,11 @@ use Webkul\Purchase\Enums\RequisitionState;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\PurchaseAgreementResource;
 use Webkul\Purchase\Models\Requisition;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditPurchaseAgreement extends EditRecord
 {
+    use HasRecordNavigationTabs;
     use HasRepeaterColumnManager;
 
     protected static string $resource = PurchaseAgreementResource::class;

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/ViewPurchaseAgreement.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseAgreementResource/Pages/ViewPurchaseAgreement.php
@@ -8,9 +8,12 @@ use Filament\Resources\Pages\ViewRecord;
 use Webkul\Chatter\Filament\Actions\ChatterAction;
 use Webkul\Purchase\Enums\RequisitionState;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\PurchaseAgreementResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewPurchaseAgreement extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = PurchaseAgreementResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseOrderResource.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/PurchaseOrderResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -29,8 +28,6 @@ class PurchaseOrderResource extends OrderResource
     protected static ?int $navigationSort = 2;
 
     protected static ?string $cluster = Orders::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationLabel(): string
     {

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/QuotationResource.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/QuotationResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\QuotationResource\Pages\CreateQuotation;
@@ -22,8 +21,6 @@ class QuotationResource extends OrderResource
     protected static bool $shouldRegisterNavigation = true;
 
     protected static ?string $recordTitleAttribute = 'name';
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static ?int $navigationSort = 1;
 

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Webkul\Field\Filament\Traits\HasCustomFields;
@@ -33,8 +32,6 @@ class VendorResource extends BaseVendorResource
     protected static ?string $cluster = Orders::class;
 
     protected static ?int $navigationSort = 4;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static ?string $recordTitleAttribute = 'name';
 

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ListVendors.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ListVendors.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\VendorResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\VendorResource\Pages\ListVendors as BaseListVendors;
@@ -11,11 +10,6 @@ use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\VendorResource;
 class ListVendors extends BaseListVendors
 {
     protected static string $resource = VendorResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 
     public function table(Table $table): Table
     {

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ManageBills.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ManageBills.php
@@ -8,9 +8,12 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Table;
 use Webkul\Invoice\Filament\Clusters\Vendors\Resources\BillResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\VendorResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageBills extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = VendorResource::class;
 
     protected static string $relationship = 'accountMoves';

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ManagePurchases.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Orders/Resources/VendorResource/Pages/ManagePurchases.php
@@ -8,9 +8,12 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Table;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\QuotationResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Orders\Resources\VendorResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManagePurchases extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = VendorResource::class;
 
     protected static string $relationship = 'orders';

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Products/Resources/ProductResource.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Products/Resources/ProductResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Purchase\Filament\Admin\Clusters\Products\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Schemas\Schema;
 use Webkul\Field\Filament\Traits\HasCustomFields;
@@ -30,8 +29,6 @@ class ProductResource extends BaseProductResource
     protected static ?string $cluster = Products::class;
 
     protected static ?int $navigationSort = 1;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static ?string $recordTitleAttribute = 'name';
 

--- a/plugins/webkul/purchases/src/Filament/Admin/Clusters/Products/Resources/ProductResource/Pages/ManageVendors.php
+++ b/plugins/webkul/purchases/src/Filament/Admin/Clusters/Products/Resources/ProductResource/Pages/ManageVendors.php
@@ -13,9 +13,12 @@ use Illuminate\Support\Facades\Auth;
 use Webkul\Product\Models\ProductSupplier;
 use Webkul\Purchase\Filament\Admin\Clusters\Configurations\Resources\VendorPriceResource;
 use Webkul\Purchase\Filament\Admin\Clusters\Products\Resources\ProductResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageVendors extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ProductResource::class;
 
     protected static string $relationship = 'supplierInformation';

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource.php
@@ -18,7 +18,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Pages\Page;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\Resource;
@@ -68,8 +67,6 @@ class ApplicantResource extends Resource
     protected static ?string $cluster = Applications::class;
 
     protected static ?int $navigationSort = 2;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource/Pages/EditApplicant.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource/Pages/EditApplicant.php
@@ -26,9 +26,12 @@ use Webkul\Recruitment\Models\Applicant;
 use Webkul\Recruitment\Models\RefuseReason;
 use Webkul\Security\Models\User;
 use Webkul\Support\Services\EmailService;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditApplicant extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ApplicantResource::class;
 
     protected array $notificationData = [];

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource/Pages/ViewApplicant.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/ApplicantResource/Pages/ViewApplicant.php
@@ -20,9 +20,12 @@ use Webkul\Recruitment\Mail\ApplicantRefuseMail;
 use Webkul\Recruitment\Models\Applicant;
 use Webkul\Recruitment\Models\RefuseReason;
 use Webkul\Support\Services\EmailService;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewApplicant extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = ApplicantResource::class;
 
     protected function getHeaderActions(): array
@@ -54,7 +57,7 @@ class ViewApplicant extends ViewRecord
                         ->inline()
                         ->options(RecruitmentState::class),
                 ])
-                ->fillForm(fn($record) => [
+                ->fillForm(fn ($record) => [
                     'state' => $record->state,
                 ])
                 ->tooltip(function ($record) {
@@ -83,7 +86,7 @@ class ViewApplicant extends ViewRecord
                 }),
             Action::make('gotoEmployee')
                 ->tooltip(__('recruitments::filament/clusters/applications/resources/applicant/pages/edit-applicant.goto-employee'))
-                ->visible(fn($record) => $record->application_status->value == ApplicationStatus::HIRED->value || $record->candidate->employee_id)
+                ->visible(fn ($record) => $record->application_status->value == ApplicationStatus::HIRED->value || $record->candidate->employee_id)
                 ->icon('heroicon-s-arrow-top-right-on-square')
                 ->iconButton()
                 ->action(function (Applicant $record) {
@@ -95,7 +98,7 @@ class ViewApplicant extends ViewRecord
                 ->setResource(static::$resource),
             Action::make('createEmployee')
                 ->label(__('recruitments::filament/clusters/applications/resources/applicant/pages/edit-applicant.create-employee'))
-                ->hidden(fn($record) => $record->application_status->value == ApplicationStatus::HIRED->value || $record->candidate->employee_id)
+                ->hidden(fn ($record) => $record->application_status->value == ApplicationStatus::HIRED->value || $record->candidate->employee_id)
                 ->action(function (Applicant $record) {
                     $employee = $record->createEmployee();
 
@@ -110,7 +113,7 @@ class ViewApplicant extends ViewRecord
                 ),
             Action::make('Refuse')
                 ->modalIcon('heroicon-s-bug-ant')
-                ->hidden(fn($record) => $record->refuse_reason_id || $record->application_status->value === ApplicationStatus::ARCHIVED->value)
+                ->hidden(fn ($record) => $record->refuse_reason_id || $record->application_status->value === ApplicationStatus::ARCHIVED->value)
                 ->modalHeading('Refuse Reason')
                 ->schema(function (Schema $schema, $record) {
                     return $schema->components([
@@ -123,10 +126,10 @@ class ViewApplicant extends ViewRecord
                             ->inline()
                             ->live()
                             ->default(true)
-                            ->visible(fn(Get $get) => $get('refuse_reason_id'))
+                            ->visible(fn (Get $get) => $get('refuse_reason_id'))
                             ->label('Notify'),
                         TextInput::make('email')
-                            ->visible(fn(Get $get) => $get('notify') && $get('refuse_reason_id'))
+                            ->visible(fn (Get $get) => $get('notify') && $get('refuse_reason_id'))
                             ->default($record->candidate->email_from)
                             ->label('Email To'),
                     ]);
@@ -157,7 +160,7 @@ class ViewApplicant extends ViewRecord
                         ->send();
                 }),
             Action::make('Restore')
-                ->hidden(fn($record) => ! $record->refuse_reason_id)
+                ->hidden(fn ($record) => ! $record->refuse_reason_id)
                 ->modalHeading('Restore Applicant from refuse')
                 ->requiresConfirmation()
                 ->color('gray')

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource.php
@@ -17,7 +17,6 @@ use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Resources\Resource;
@@ -55,8 +54,6 @@ class CandidateResource extends Resource
     protected static ?string $cluster = Applications::class;
 
     protected static ?int $navigationSort = 3;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/CreateCandidate.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/CreateCandidate.php
@@ -9,6 +9,15 @@ use Webkul\Recruitment\Filament\Clusters\Applications\Resources\CandidateResourc
 
 class CreateCandidate extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = CandidateResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/EditCandidate.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/EditCandidate.php
@@ -10,9 +10,12 @@ use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Employee\Filament\Resources\EmployeeResource;
 use Webkul\Recruitment\Filament\Clusters\Applications\Resources\CandidateResource;
 use Webkul\Recruitment\Models\Candidate;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditCandidate extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = CandidateResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/ManageSkill.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/ManageSkill.php
@@ -5,10 +5,11 @@ namespace Webkul\Recruitment\Filament\Clusters\Applications\Resources\CandidateR
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Webkul\Recruitment\Filament\Clusters\Applications\Resources\CandidateResource;
 use Webkul\Recruitment\Traits\CandidateSkillRelation;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageSkill extends ManageRelatedRecords
 {
-    use CandidateSkillRelation;
+    use CandidateSkillRelation, HasRecordNavigationTabs;
 
     protected static string $resource = CandidateResource::class;
 

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/ViewCandidate.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/CandidateResource/Pages/ViewCandidate.php
@@ -10,9 +10,12 @@ use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Employee\Filament\Resources\EmployeeResource;
 use Webkul\Recruitment\Filament\Clusters\Applications\Resources\CandidateResource;
 use Webkul\Recruitment\Models\Candidate;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewCandidate extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = CandidateResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/JobByPositionResource.php
+++ b/plugins/webkul/recruitments/src/Filament/Clusters/Applications/Resources/JobByPositionResource.php
@@ -5,7 +5,6 @@ namespace Webkul\Recruitment\Filament\Clusters\Applications\Resources;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\EditAction;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\FontWeight;
@@ -27,8 +26,6 @@ class JobByPositionResource extends Resource
     protected static ?string $cluster = Applications::class;
 
     protected static ?int $navigationSort = 1;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Tables\Table;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\PartnerResource as BaseCustomerResource;
@@ -27,8 +26,6 @@ class CustomerResource extends BaseCustomerResource
     protected static ?string $cluster = Orders::class;
 
     protected static ?int $navigationSort = 3;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/CreateCustomer.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/CreateCustomer.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Illuminate\Contracts\Support\Htmlable;
 use Webkul\Partner\Filament\Resources\PartnerResource\Pages\CreatePartner as BaseCreateCustomer;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
@@ -11,9 +10,13 @@ class CreateCustomer extends BaseCreateCustomer
 {
     protected static string $resource = CustomerResource::class;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
+    public function getSubNavigation(): array
     {
-        return SubNavigationPosition::Top;
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
     }
 
     public function getTitle(): string|Htmlable

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/EditCustomer.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/EditCustomer.php
@@ -2,19 +2,16 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Illuminate\Contracts\Support\Htmlable;
 use Webkul\Partner\Filament\Resources\PartnerResource\Pages\EditPartner as BaseEditCustomer;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditCustomer extends BaseEditCustomer
 {
-    protected static string $resource = CustomerResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = CustomerResource::class;
 
     public function getTitle(): string|Htmlable
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageAddresses.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageAddresses.php
@@ -2,16 +2,13 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\PartnerResource\Pages\ManageAddresses as BaseManageAddresses;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageAddresses extends BaseManageAddresses
 {
-    protected static string $resource = CustomerResource::class;
+    use HasRecordNavigationTabs;
 
-    public  static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = CustomerResource::class;
 }

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageBankAccounts.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageBankAccounts.php
@@ -2,16 +2,13 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\PartnerResource\Pages\ManageBankAccounts as BaseManageBankAccounts;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageBankAccounts extends BaseManageBankAccounts
 {
-    protected static string $resource = CustomerResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = CustomerResource::class;
 }

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageContacts.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ManageContacts.php
@@ -2,16 +2,13 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\PartnerResource\Pages\ManageContacts as BaseManageContacts;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageContacts extends BaseManageContacts
 {
-    protected static string $resource = CustomerResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = CustomerResource::class;
 }

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ViewCustomer.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/CustomerResource/Pages/ViewCustomer.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Partner\Filament\Resources\PartnerResource\Pages\ViewPartner as BaseViewCustomer;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\CustomerResource;
 
 class ViewCustomer extends BaseViewCustomer
 {
     protected static string $resource = CustomerResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/OrderResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/OrderResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\Orders\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -26,8 +25,6 @@ class OrderResource extends Resource
     protected static ?string $cluster = Orders::class;
 
     protected static ?int $navigationSort = 2;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource.php
@@ -21,7 +21,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Actions;
@@ -85,8 +84,6 @@ class QuotationResource extends Resource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
 
     protected static ?string $cluster = Orders::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/CreateQuotation.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/CreateQuotation.php
@@ -22,6 +22,15 @@ class CreateQuotation extends CreateRecord
         return $this->getResource()::getUrl('edit', ['record' => $this->getRecord()]);
     }
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected function getCreatedNotification(): ?Notification
     {
         return Notification::make()

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/EditQuotation.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/EditQuotation.php
@@ -4,7 +4,6 @@ namespace Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource\Pages
 
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\EditRecord;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Sale\Enums\OrderState;
@@ -12,9 +11,11 @@ use Webkul\Sale\Facades\SaleOrder;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource\Actions as BaseActions;
 use Webkul\Support\Concerns\HasRepeaterColumnManager;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class EditQuotation extends EditRecord
 {
+    use HasRecordNavigationTabs;
     use HasRepeaterColumnManager;
 
     protected static string $resource = QuotationResource::class;
@@ -22,11 +23,6 @@ class EditQuotation extends EditRecord
     protected function getRedirectUrl(): string
     {
         return $this->getResource()::getUrl('edit', ['record' => $this->getRecord()]);
-    }
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
     }
 
     protected function getSavedNotification(): ?Notification
@@ -50,7 +46,7 @@ class EditQuotation extends EditRecord
             BaseActions\SendByEmailAction::make(),
             BaseActions\LockAndUnlockAction::make(),
             DeleteAction::make()
-                ->hidden(fn() => $this->getRecord()->state == OrderState::SALE)
+                ->hidden(fn () => $this->getRecord()->state == OrderState::SALE)
                 ->successNotification(
                     Notification::make()
                         ->success()

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ManageDeliveries.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ManageDeliveries.php
@@ -7,13 +7,16 @@ use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Table;
 use Livewire\Livewire;
-use Webkul\Inventory\Filament\Clusters\Operations\Resources\OperationResource;
 use Webkul\Inventory\Filament\Clusters\Operations\Resources\DeliveryResource;
+use Webkul\Inventory\Filament\Clusters\Operations\Resources\OperationResource;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource;
 use Webkul\Support\Package;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageDeliveries extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = QuotationResource::class;
 
     protected static string $relationship = 'operations';

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ManageInvoices.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ManageInvoices.php
@@ -4,25 +4,22 @@ namespace Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource\Pages
 
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Table;
 use Livewire\Livewire;
 use Webkul\Account\Filament\Resources\InvoiceResource;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ManageInvoices extends ManageRelatedRecords
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = QuotationResource::class;
 
     protected static string $relationship = 'accountMoves';
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-banknotes';
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 
     public static function getNavigationLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ViewQuotation.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Orders/Resources/QuotationResource/Pages/ViewQuotation.php
@@ -4,21 +4,18 @@ namespace Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource\Pages
 
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\ViewRecord;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
 use Webkul\Sale\Enums\OrderState;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource;
 use Webkul\Sale\Filament\Clusters\Orders\Resources\QuotationResource\Actions as BaseActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 
 class ViewQuotation extends ViewRecord
 {
-    protected static string $resource = QuotationResource::class;
+    use HasRecordNavigationTabs;
 
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
+    protected static string $resource = QuotationResource::class;
 
     protected function getHeaderActions(): array
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Products/Resources/ProductResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Products/Resources/ProductResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\Products\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Webkul\Invoice\Filament\Clusters\Customer\Resources\ProductResource as BaseProductResource;
 use Webkul\Sale\Filament\Clusters\Products;
@@ -23,8 +22,6 @@ class ProductResource extends BaseProductResource
     protected static bool $shouldRegisterNavigation = true;
 
     protected static ?string $cluster = Products::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getRecordSubNavigation(Page $page): array
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ViewProduct.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/Products/Resources/ProductResource/Pages/ViewProduct.php
@@ -2,16 +2,10 @@
 
 namespace Webkul\Sale\Filament\Clusters\Products\Resources\ProductResource\Pages;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\Product\Filament\Resources\ProductResource\Pages\ViewProduct as BaseViewProduct;
 use Webkul\Sale\Filament\Clusters\Products\Resources\ProductResource;
 
 class ViewProduct extends BaseViewProduct
 {
     protected static string $resource = ProductResource::class;
-
-    public static function getSubNavigationPosition(): SubNavigationPosition
-    {
-        return SubNavigationPosition::Top;
-    }
 }

--- a/plugins/webkul/sales/src/Filament/Clusters/ToInvoice/Resources/OrderToInvoiceResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/ToInvoice/Resources/OrderToInvoiceResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\ToInvoice\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -22,8 +21,6 @@ class OrderToInvoiceResource extends Resource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-arrow-down';
 
     protected static ?string $cluster = ToInvoice::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/sales/src/Filament/Clusters/ToInvoice/Resources/OrderToUpsellResource.php
+++ b/plugins/webkul/sales/src/Filament/Clusters/ToInvoice/Resources/OrderToUpsellResource.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Sale\Filament\Clusters\ToInvoice\Resources;
 
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
@@ -19,8 +18,6 @@ class OrderToUpsellResource extends Resource
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-arrow-up';
 
     protected static ?string $cluster = ToInvoice::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource.php
@@ -16,7 +16,6 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
@@ -48,8 +47,6 @@ class MyAllocationResource extends Resource
     protected static ?int $navigationSort = 3;
 
     protected static ?string $modelLabel = 'My Allocation';
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/CreateMyAllocation.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/CreateMyAllocation.php
@@ -10,6 +10,15 @@ use Webkul\TimeOff\Filament\Clusters\MyTime\Resources\MyAllocationResource;
 
 class CreateMyAllocation extends CreateRecord
 {
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = MyAllocationResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/EditMyAllocation.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/EditMyAllocation.php
@@ -8,10 +8,13 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Auth;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TimeOff\Filament\Clusters\MyTime\Resources\MyAllocationResource;
 
 class EditMyAllocation extends EditRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = MyAllocationResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/ViewMyAllocation.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyAllocationResource/Pages/ViewMyAllocation.php
@@ -7,10 +7,13 @@ use Filament\Actions\EditAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TimeOff\Filament\Clusters\MyTime\Resources\MyAllocationResource;
 
 class ViewMyAllocation extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = MyAllocationResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource.php
@@ -4,7 +4,6 @@ namespace Webkul\TimeOff\Filament\Clusters\MyTime\Resources;
 
 use Filament\Infolists\Components\ImageEntry;
 use Filament\Infolists\Components\TextEntry;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
@@ -32,8 +31,6 @@ class MyTimeOffResource extends Resource
     protected static ?int $navigationSort = 2;
 
     protected static ?string $cluster = MyTime::class;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getModelLabel(): string
     {

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/CreateMyTimeOff.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/CreateMyTimeOff.php
@@ -11,6 +11,15 @@ class CreateMyTimeOff extends CreateRecord
 {
     use TimeOffHelper;
 
+    public function getSubNavigation(): array
+    {
+        if (filled($cluster = static::getCluster())) {
+            return $this->generateNavigationItems($cluster::getClusteredComponents());
+        }
+
+        return [];
+    }
+
     protected static string $resource = MyTimeOffResource::class;
 
     protected function getRedirectUrl(): string

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/EditMyTimeOff.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/EditMyTimeOff.php
@@ -7,11 +7,13 @@ use Filament\Actions\ViewAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TimeOff\Filament\Clusters\MyTime\Resources\MyTimeOffResource;
 use Webkul\TimeOff\Traits\TimeOffHelper;
 
 class EditMyTimeOff extends EditRecord
 {
+    use HasRecordNavigationTabs;
     use TimeOffHelper;
 
     protected static string $resource = MyTimeOffResource::class;

--- a/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/ViewMyTimeOff.php
+++ b/plugins/webkul/time-off/src/Filament/Clusters/MyTime/Resources/MyTimeOffResource/Pages/ViewMyTimeOff.php
@@ -7,10 +7,13 @@ use Filament\Actions\EditAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Webkul\Chatter\Filament\Actions as ChatterActions;
+use Webkul\Support\Traits\HasRecordNavigationTabs;
 use Webkul\TimeOff\Filament\Clusters\MyTime\Resources\MyTimeOffResource;
 
 class ViewMyTimeOff extends ViewRecord
 {
+    use HasRecordNavigationTabs;
+
     protected static string $resource = MyTimeOffResource::class;
 
     protected function getHeaderActions(): array

--- a/plugins/webkul/time-off/src/Filament/Pages/Dashboard.php
+++ b/plugins/webkul/time-off/src/Filament/Pages/Dashboard.php
@@ -4,14 +4,14 @@ namespace Webkul\TimeOff\Filament\Pages;
 
 use BezhanSalleh\FilamentShield\Traits\HasPageShield;
 use Filament\Pages\Dashboard as BaseDashboard;
-use Filament\Pages\Enums\SubNavigationPosition;
 use Webkul\TimeOff\Filament\Clusters\MyTime;
 use Webkul\TimeOff\Filament\Widgets\CalendarWidget;
 use Webkul\TimeOff\Filament\Widgets\MyTimeOffWidget;
 
 class Dashboard extends BaseDashboard
 {
-     use HasPageShield;
+    use HasPageShield;
+
     protected static string $routePath = 'time-off';
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-squares-2x2';
@@ -19,8 +19,6 @@ class Dashboard extends BaseDashboard
     protected static ?string $cluster = MyTime::class;
 
     protected static ?int $navigationSort = 1;
-
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     public static function getNavigationLabel(): string
     {


### PR DESCRIPTION
This enhances the page navigation experience by displaying cluster navigation on the left and record navigation at the top. The changes ensure both navigation types work together smoothly across edit, view, and manager-related pages, providing a more organized and intuitive layout.