### PR TITLE
fix: fix issue 1055 inactive currency filter

### DIFF
--- a/plugins/webkul/security/src/Filament/Resources/CompanyResource/RelationManagers/BranchesRelationManager.php
+++ b/plugins/webkul/security/src/Filament/Resources/CompanyResource/RelationManagers/BranchesRelationManager.php
@@ -156,7 +156,6 @@ class BranchesRelationManager extends RelationManager
                                                 modifyQueryUsing: fn (Builder $query) => $query->where('active', 1),
                                             )
                                             ->label(__('security::filament/resources/company/relation-managers/manage-branch.form.tabs.address-information.sections.additional-information.fields.default-currency'))
-                                            ->relationship('currency', 'full_name')
                                             ->searchable()
                                             ->required()
                                             ->live()

--- a/plugins/webkul/support/src/Filament/Resources/CompanyResource/RelationManagers/BranchesRelationManager.php
+++ b/plugins/webkul/support/src/Filament/Resources/CompanyResource/RelationManagers/BranchesRelationManager.php
@@ -155,7 +155,6 @@ class BranchesRelationManager extends RelationManager
                                                 modifyQueryUsing: fn (Builder $query) => $query->where('active', 1),
                                             )
                                             ->label(__('support::filament/resources/company/relation-managers/manage-branch.form.tabs.address-information.sections.additional-information.fields.default-currency'))
-                                            ->relationship('currency', 'full_name')
                                             ->searchable()
                                             ->required()
                                             ->live()


### PR DESCRIPTION
🔗 Related Issue
Fixes #1055

📝 Summary of Changes
This PR ensures that only currencies marked as Active in the system configuration are visible and selectable during the creation or editing of a Company or Branch.

Changes included:

BranchesRelationManager.php: Removed a duplicate ->relationship('currency', 'full_name') call that was overwriting the filtered query and causing inactive currencies to appear in the dropdown.

CompanyResource.php: Verified and ensured the modifyQueryUsing filter is correctly applied to the currency relationship.

🛠️ Technical Details
In Filament, calling ->relationship() multiple times on the same component overwrites previous configurations. In BranchesRelationManager.php, the second call was lacking the Builder constraint, effectively nullifying the where('active', 1) filter.

✅ Testing Steps

- Go to Currency Configuration.
- Mark one or more currencies as Inactive.
- Save the configuration.
- Navigate to Company / Branch → Create.
- Click on the Currency dropdown.