### PR TITLE
fix: fix issue 1054 accounting cross company visibility

### DIFF
--- a/plugins/webkul/accounting/src/Filament/Clusters/Accounting/Resources/JournalEntryResource.php
+++ b/plugins/webkul/accounting/src/Filament/Clusters/Accounting/Resources/JournalEntryResource.php
@@ -404,7 +404,8 @@ class JournalEntryResource extends Resource
                     ->exporter(JournalEntryExporter::class),
             ])
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with('currency');
+                $query->with('currency')
+                    ->where('company_id', Auth::user()->default_company_id);
             });
     }
 

--- a/plugins/webkul/accounting/src/Filament/Clusters/Accounting/Resources/JournalItemResource.php
+++ b/plugins/webkul/accounting/src/Filament/Clusters/Accounting/Resources/JournalItemResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use Webkul\Accounting\Filament\Clusters\Accounting;
 use Webkul\Accounting\Filament\Clusters\Accounting\Resources\JournalItemResource\Pages\ListJournalItems;
 use Webkul\Accounting\Filament\Exports\JournalItemExporter;
@@ -297,7 +298,8 @@ class JournalItemResource extends Resource
                     ->exporter(JournalItemExporter::class),
             ])
             ->modifyQueryUsing(function (Builder $query) {
-                $query->with(['currency', 'account', 'partner', 'journal', 'company', 'move']);
+                $query->with(['currency', 'account', 'partner', 'journal', 'company', 'move'])
+                    ->where('company_id', Auth::user()->default_company_id);
             })
             ->defaultSort('date', 'desc');
     }


### PR DESCRIPTION
Restrict accounting data visibility to the user's default company

🔗 Related Issue
Fixes #1054

📝 Summary of Changes
This PR addresses a critical cross-company data visibility bug where users could view financial records (Journal Entries and Journal Items) belonging to companies other than their active default company.

Changes included:

JournalEntryResource.php: Added a query scope to the table() method to filter entries by default_company_id.

JournalItemResource.php: Secured granular financial line items by restricting the table query to the user's default company.

🛠️ Technical Details
The fix uses the default_company_id column on the User model. By applying a where constraint within Filament's modifyQueryUsing hook, we ensure that the database only returns records associated with the user's currently active company.


I investigated the user_allowed_companies table and this doesn't seem to be implemented yet so i've avoided for now.