### PR TITLE
fix: logged in user delete itself

### DIFF
--- a/plugins/webkul/security/src/Filament/Resources/UserResource.php
+++ b/plugins/webkul/security/src/Filament/Resources/UserResource.php
@@ -122,6 +122,7 @@ class UserResource extends Resource
                                             ->label(__('security::filament/resources/user.form.sections.permissions.fields.roles'))
                                             ->relationship('roles', 'name')
                                             ->multiple()
+                                            ->required()
                                             ->preload()
                                             ->searchable(),
                                         Select::make('resource_permission')
@@ -490,7 +491,7 @@ class UserResource extends Resource
 
     public static function canDeleteUser(User $record): bool
     {
-        return ! $record->is_default;
+        return ! $record->is_default && $record->id !== Auth::id();
     }
 
     public static function getPages(): array

--- a/plugins/webkul/security/src/Policies/UserPolicy.php
+++ b/plugins/webkul/security/src/Policies/UserPolicy.php
@@ -59,6 +59,10 @@ class UserPolicy
             return false;
         }
 
+        if ($user->id === $record->id) {
+            return false;
+        }
+
         return $this->hasAccess($user, $record, 'creator');
     }
 
@@ -76,6 +80,10 @@ class UserPolicy
     public function forceDelete(User $user, User $record): bool
     {
         if (! $user->can('force_delete_security_user')) {
+            return false;
+        }
+
+        if ($user->id === $record->id) {
             return false;
         }
 


### PR DESCRIPTION
### Fixed:

-> A logged-in user can't delete itself
-> making roles a required field 