### PR TITLE
Fix an error in the project dashboard

### DIFF
--- a/plugins/webkul/projects/src/Filament/Widgets/TopAssigneesWidget.php
+++ b/plugins/webkul/projects/src/Filament/Widgets/TopAssigneesWidget.php
@@ -68,7 +68,7 @@ class TopAssigneesWidget extends BaseWidget
                 COUNT(DISTINCT task_id) as total_tasks
             ')
             ->whereBetween('analytic_records.created_at', [$startDate, $endDate])
-            ->groupBy('user_id')
+            ->groupBy('user_id', 'users.name')
             ->orderByRaw('SUM(unit_amount) DESC')
             ->limit(10);
 


### PR DESCRIPTION
An exception is thrown by the groupBy in the TopAssigneesWidget

<img width="1086" height="352" alt="image" src="https://github.com/user-attachments/assets/58019b86-2d0c-439c-9eea-41283b829ec4" />
