### PR TITLE
fix: handle missing `timeout` command on macOS and Windows

### DIFF
--- a/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
+++ b/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
@@ -511,6 +511,16 @@ class InstallCommand extends Command
             return $command;
         }
 
+        if (PHP_OS_FAMILY === 'Darwin') {
+            $gtimeout = trim((string) shell_exec('which gtimeout 2>/dev/null'));
+
+            if ($gtimeout !== '') {
+                return "gtimeout {$seconds} {$command}";
+            }
+
+            return $command;
+        }
+
         return "timeout {$seconds} {$command}";
     }
 }

--- a/plugins/webkul/plugin-manager/src/Filament/Resources/PluginResource.php
+++ b/plugins/webkul/plugin-manager/src/Filament/Resources/PluginResource.php
@@ -149,8 +149,6 @@ class PluginResource extends Resource
 
                                 $commandName = escapeshellarg("{$record->name}:install");
 
-                                $cmd = "timeout 300 $php $artisan $commandName 2>&1";
-
                                 $cmd = self::buildTimeoutCommand(300, "$php $artisan $commandName 2>&1");
 
                                 $output = [];
@@ -454,6 +452,16 @@ class PluginResource extends Resource
     protected static function buildTimeoutCommand(int $seconds, string $command): string
     {
         if (PHP_OS_FAMILY === 'Windows') {
+            return $command;
+        }
+
+        if (PHP_OS_FAMILY === 'Darwin') {
+            $gtimeout = trim((string) shell_exec('which gtimeout 2>/dev/null'));
+
+            if ($gtimeout !== '') {
+                return "gtimeout {$seconds} {$command}";
+            }
+
             return $command;
         }
 


### PR DESCRIPTION
## Problem

Plugin installation fails on macOS with:
Installation failed with exit code 127. Last output: sh: timeout: command not found


The `timeout` command is a GNU coreutils utility available on Linux but **not** on macOS (Darwin) or Windows by default.

## Solution

Updated `buildTimeoutCommand()` in both `PluginResource` and `InstallCommand` to handle all three platforms:

- **Linux** — uses `timeout {seconds} {command}` as before
- **macOS (Darwin)** — uses `gtimeout` if installed via `brew install coreutils`, otherwise runs the command without a timeout
- **Windows** — runs the command without a timeout (unchanged)

Also removed a stale hardcoded `timeout 300 ...` line in `PluginResource` that was immediately overwritten by `buildTimeoutCommand()`.

## Files Changed

- `plugins/webkul/plugin-manager/src/Filament/Resources/PluginResource.php`
- `plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php`