### PR TITLE
fix(plugin-manager): normalize path separators in translations:check for Windows

### DIFF
--- a/plugins/webkul/plugin-manager/src/Console/Commands/FindMissingTranslations.php
+++ b/plugins/webkul/plugin-manager/src/Console/Commands/FindMissingTranslations.php
@@ -117,6 +117,8 @@ class FindMissingTranslations extends Command
 
     protected function processLangFolder(string $name, string $langRoot, ?string $targetLocale): void
     {
+        $langRoot = str_replace('\\', '/', $langRoot);
+
         $enPath = $langRoot.'/'.self::BASE_LOCALE;
 
         if (! File::isDirectory($enPath)) {
@@ -856,7 +858,7 @@ class FindMissingTranslations extends Command
 
         return collect(File::allFiles($dir))
             ->filter(fn ($file) => $file->getExtension() === 'php')
-            ->map(fn ($file) => $file->getPathname())
+            ->map(fn ($file) => str_replace('\\', '/', $file->getPathname()))
             ->sort()
             ->values();
     }


### PR DESCRIPTION
The `translations:check` command fails on Windows: `File::allFiles()` returns paths with OS-native backslashes, but the relative-path extraction in `processLangFolder` and `getPhpFiles` assumes `/`, so `Str::after($file, $enPath.'/')` never strips the prefix and every locale file is reported as **both missing and extra**.

This change normalizes separators to `/` at two points:
- `processLangFolder` start: `$langRoot = str_replace('\\', '/', $langRoot);`
- `getPhpFiles` map step: `str_replace('\\', '/', $file->getPathname())`

The fix is a no-op on Linux/macOS (no backslashes to replace), so existing CI behavior is unchanged.

Verified locally on Windows 11 + Herd PHP 8.4 against a fresh `es` clone of two plugins — `translations:check --locale=es --plugin=<name>` correctly reports `PASS` instead of `29 missing + 29 extra`.
