### PR TITLE
feat(manufacturing): add Spanish (es) translations

### DIFF
--- a/plugins/webkul/manufacturing/resources/lang/es/app.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/app.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'navigation' => [
+        'group' => 'Fabricación',
+
+        'settings' => [
+            'label' => 'Configuración',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-consumption.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-consumption.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'flexible' => 'Permitido',
+    'warning'  => 'Permitido con advertencia',
+    'strict'   => 'Bloqueado',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-ready-to-produce.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-ready-to-produce.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'all-available' => 'Cuando todos los componentes están disponibles',
+    'asap'          => 'Cuando los componentes de la primera operación están disponibles',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-type.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/bill-of-material-type.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'normal'  => 'Fabricar este producto',
+    'phantom' => 'Kit',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-priority.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-priority.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'normal' => 'Normal',
+    'urgent' => 'Urgente',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-reservation-state.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-reservation-state.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'confirmed' => 'En espera',
+    'assigned'  => 'Asignado',
+    'waiting'   => 'En espera de otra operación',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-state.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/manufacturing-order-state.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'draft'     => 'Borrador',
+    'confirmed' => 'Confirmado',
+    'progress'  => 'En progreso',
+    'to-close'  => 'Por cerrar',
+    'done'      => 'Realizado',
+    'cancel'    => 'Cancelado',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/operation-time-mode.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/operation-time-mode.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'auto'   => 'Calcular según tiempo registrado',
+    'manual' => 'Establecer duración manualmente',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/operation-worksheet-type.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/operation-worksheet-type.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'pdf'          => 'PDF',
+    'google-slide' => 'Google Slide',
+    'text'         => 'Texto',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/unbuild-order-state.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/unbuild-order-state.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'draft' => 'Borrador',
+    'done'  => 'Realizado',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/work-center-working-state.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/work-center-working-state.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'normal'  => 'Normal',
+    'blocked' => 'Bloqueado',
+    'done'    => 'En progreso',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/work-order-production-availability.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/work-order-production-availability.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'confirmed' => 'En espera',
+    'assigned'  => 'Listo',
+    'waiting'   => 'En espera de otra operación',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/enums/work-order-state.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/enums/work-order-state.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'pending'  => 'En espera de otra orden de trabajo',
+    'waiting'  => 'En espera de componentes',
+    'ready'    => 'Listo',
+    'progress' => 'En progreso',
+    'done'     => 'Terminado',
+    'cancel'   => 'Cancelado',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Configuraciones',
+        'group' => 'Fabricación',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation.php
@@ -1,0 +1,159 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Operaciones',
+        'group' => 'Configuración',
+    ],
+
+    'form' => [
+        'sections' => [
+            'general' => [
+                'title'  => 'General',
+                'fields' => [
+                    'name'              => 'Operación',
+                    'name-placeholder'  => 'p. ej. Corte',
+                    'bill-of-material'  => 'Lista de materiales',
+                    'work-center'       => 'Centro de trabajo',
+                    'apply-on-variants' => 'Aplicar en variantes',
+                    'company'           => 'Empresa',
+                    'blocked-by'        => 'Bloqueado por',
+                ],
+            ],
+            'settings' => [
+                'title'  => 'Configuración',
+                'fields' => [
+                    'time-mode'                  => 'Cálculo de duración',
+                    'time-mode-batch'            => 'Basado en',
+                    'time-mode-batch-prefix'     => 'las últimas',
+                    'time-mode-batch-suffix'     => 'órdenes de trabajo',
+                    'manual-cycle-time'          => 'Duración predeterminada',
+                    'manual-cycle-time-suffix'   => 'minutos',
+                ],
+            ],
+            'worksheet' => [
+                'title'  => 'Hoja de trabajo',
+                'fields' => [
+                    'worksheet'                => 'Hoja de trabajo',
+                    'pdf'                      => 'PDF',
+                    'google-slide'             => 'Google Slide',
+                    'google-slide-placeholder' => 'Enlace de Google Slide',
+                    'description'              => 'Descripción',
+                    'description-placeholder'  => 'Descripción de la operación...',
+                ],
+            ],
+        ],
+    ],
+
+    'table' => [
+        'columns' => [
+            'name'              => 'Operación',
+            'bill-of-material'  => 'Lista de materiales',
+            'work-center'       => 'Centro de trabajo',
+            'time-mode'         => 'Cálculo de duración',
+            'manual-cycle-time' => 'Duración predeterminada',
+            'worksheet-type'    => 'Hoja de trabajo',
+            'deleted-at'        => 'Eliminado el',
+            'created-at'        => 'Creado el',
+            'updated-at'        => 'Actualizado el',
+        ],
+        'filters' => [
+            'work-center'    => 'Centro de trabajo',
+            'time-mode'      => 'Cálculo de duración',
+            'worksheet-type' => 'Hoja de trabajo',
+        ],
+        'actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Operación restaurada',
+                    'body'  => 'La operación ha sido restaurada correctamente.',
+                ],
+            ],
+            'delete' => [
+                'notification' => [
+                    'title' => 'Operación archivada',
+                    'body'  => 'La operación ha sido archivada correctamente.',
+                ],
+            ],
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Operación eliminada',
+                        'body'  => 'La operación ha sido eliminada permanentemente.',
+                    ],
+                    'error' => [
+                        'title' => 'No se pudo eliminar la operación',
+                        'body'  => 'No es posible eliminar la operación porque está en uso.',
+                    ],
+                ],
+            ],
+        ],
+        'bulk-actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Operaciones restauradas',
+                    'body'  => 'Las operaciones seleccionadas han sido restauradas correctamente.',
+                ],
+            ],
+            'delete' => [
+                'notification' => [
+                    'title' => 'Operaciones archivadas',
+                    'body'  => 'Las operaciones seleccionadas han sido archivadas correctamente.',
+                ],
+            ],
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Operaciones eliminadas',
+                        'body'  => 'Las operaciones seleccionadas han sido eliminadas permanentemente.',
+                    ],
+                    'error' => [
+                        'title' => 'No se pudieron eliminar las operaciones',
+                        'body'  => 'Una o más operaciones seleccionadas están en uso.',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'general' => [
+                'title'   => 'Información general',
+                'entries' => [
+                    'name'              => 'Operación',
+                    'bill-of-material'  => 'Lista de materiales',
+                    'work-center'       => 'Centro de trabajo',
+                    'apply-on-variants' => 'Aplicar en variantes',
+                    'company'           => 'Empresa',
+                ],
+            ],
+            'settings' => [
+                'title'   => 'Configuración',
+                'entries' => [
+                    'time-mode'                => 'Cálculo de duración',
+                    'time-mode-batch'          => 'Basado en',
+                    'manual-cycle-time'        => 'Duración predeterminada',
+                    'manual-cycle-time-suffix' => 'minutos',
+                ],
+            ],
+            'worksheet' => [
+                'title'   => 'Hoja de trabajo',
+                'entries' => [
+                    'worksheet'    => 'Hoja de trabajo',
+                    'pdf'          => 'PDF',
+                    'google-slide' => 'Google Slide',
+                    'description'  => 'Descripción',
+                ],
+            ],
+            'record-information' => [
+                'title'   => 'Información del registro',
+                'entries' => [
+                    'created-by'   => 'Creado por',
+                    'created-at'   => 'Creado el',
+                    'last-updated' => 'Última actualización',
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/create-operation.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/create-operation.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Operación creada',
+        'body'  => 'La operación ha sido creada correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/edit-operation.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/edit-operation.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Operación actualizada',
+        'body'  => 'La operación ha sido actualizada correctamente.',
+    ],
+    'header-actions' => [
+        'delete' => [
+            'notification' => [
+                'title' => 'Operación archivada',
+                'body'  => 'La operación ha sido archivada correctamente.',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/list-operations.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/list-operations.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'header-actions' => [
+        'create' => [
+            'label'        => 'Nueva operación',
+            'notification' => [
+                'title' => 'Operación creada',
+                'body'  => 'La operación ha sido creada correctamente.',
+            ],
+        ],
+    ],
+    'tabs' => [
+        'all'      => 'Todas',
+        'archived' => 'Archivadas',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/view-operation.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/operation/pages/view-operation.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'header-actions' => [
+        'delete' => [
+            'notification' => [
+                'title' => 'Operación archivada',
+                'body'  => 'La operación ha sido archivada correctamente.',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center.php
@@ -1,0 +1,221 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Centros de trabajo',
+        'group' => 'Configuración',
+    ],
+
+    'form' => [
+        'sections' => [
+            'general' => [
+                'title'  => 'General',
+                'fields' => [
+                    'name'                     => 'Nombre',
+                    'name-placeholder'         => 'p. ej. Línea de ensamble 1',
+                    'code'                     => 'Código',
+                    'code-placeholder'         => 'p. ej. LE1',
+                    'working-state'            => 'Estado operativo',
+                    'color'                    => 'Color',
+                    'tags'                     => 'Etiqueta',
+                    'alternative-work-centers' => 'Centros de trabajo alternativos',
+                    'company'                  => 'Empresa',
+                    'calendar'                 => 'Horas operativas',
+                ],
+            ],
+
+            'information' => [
+                'title'     => 'Información general',
+                'fieldsets' => [
+                    'production-information' => 'Información de producción',
+                    'costing-information'    => 'Información de costos',
+                ],
+                'fields' => [
+                    'default-capacity' => 'Capacidad predeterminada',
+                    'time-efficiency'  => 'Eficiencia del tiempo',
+                    'oee-target'       => 'Objetivo OEE',
+                    'costs-per-hour'   => 'Costo por hora',
+                    'cost-suffix'      => 'por hora',
+                    'setup-time'       => 'Tiempo de preparación',
+                    'cleanup-time'     => 'Tiempo de limpieza',
+                    'time-suffix'      => 'minutos',
+                ],
+            ],
+
+            'description' => [
+                'title'  => 'Descripción',
+                'fields' => [
+                    'note'             => 'Descripción',
+                    'note-placeholder' => 'Descripción del centro de trabajo...',
+                ],
+            ],
+
+            'specific-capacity' => [
+                'title'  => 'Capacidad específica',
+                'fields' => [
+                    'records' => 'Capacidad específica',
+                ],
+                'columns' => [
+                    'product'      => 'Producto',
+                    'product-uom'  => 'UOM',
+                    'capacity'     => 'Capacidad',
+                    'setup-time'   => 'Tiempo de preparación',
+                    'cleanup-time' => 'Tiempo de limpieza',
+                ],
+                'actions' => [
+                    'add' => 'Agregar una línea',
+                ],
+            ],
+        ],
+    ],
+
+    'table' => [
+        'columns' => [
+            'name'             => 'Nombre',
+            'code'             => 'Código',
+            'company'          => 'Empresa',
+            'calendar'         => 'Horas operativas',
+            'working-state'    => 'Estado operativo',
+            'default-capacity' => 'Capacidad',
+            'time-efficiency'  => 'Eficiencia',
+            'costs-per-hour'   => 'Costo por hora',
+            'deleted-at'       => 'Eliminado el',
+            'created-at'       => 'Creado el',
+            'updated-at'       => 'Actualizado el',
+        ],
+
+        'groups' => [
+            'company' => 'Empresa',
+        ],
+
+        'filters' => [
+            'company'       => 'Empresa',
+            'working-state' => 'Estado operativo',
+        ],
+
+        'actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Centro de trabajo restaurado',
+                    'body'  => 'El centro de trabajo ha sido restaurado correctamente.',
+                ],
+            ],
+
+            'delete' => [
+                'notification' => [
+                    'title' => 'Centro de trabajo archivado',
+                    'body'  => 'El centro de trabajo ha sido archivado correctamente.',
+                ],
+            ],
+
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Centro de trabajo eliminado',
+                        'body'  => 'El centro de trabajo ha sido eliminado permanentemente.',
+                    ],
+
+                    'error' => [
+                        'title' => 'No se pudo eliminar el centro de trabajo',
+                        'body'  => 'No es posible eliminar el centro de trabajo porque está en uso.',
+                    ],
+                ],
+            ],
+        ],
+
+        'bulk-actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Centros de trabajo restaurados',
+                    'body'  => 'Los centros de trabajo seleccionados han sido restaurados correctamente.',
+                ],
+            ],
+
+            'delete' => [
+                'notification' => [
+                    'title' => 'Centros de trabajo archivados',
+                    'body'  => 'Los centros de trabajo seleccionados han sido archivados correctamente.',
+                ],
+            ],
+
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Centros de trabajo eliminados',
+                        'body'  => 'Los centros de trabajo seleccionados han sido eliminados permanentemente.',
+                    ],
+
+                    'error' => [
+                        'title' => 'No se pudieron eliminar los centros de trabajo',
+                        'body'  => 'Uno o más centros de trabajo seleccionados están en uso.',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'general' => [
+                'title' => 'Información general',
+
+                'entries' => [
+                    'name'                     => 'Nombre del centro de trabajo',
+                    'code'                     => 'Código',
+                    'working-state'            => 'Estado operativo',
+                    'tags'                     => 'Etiqueta',
+                    'alternative-work-centers' => 'Centros de trabajo alternativos',
+                    'company'                  => 'Empresa',
+                    'calendar'                 => 'Horas operativas',
+                ],
+            ],
+
+            'information' => [
+                'title'     => 'Información general',
+                'fieldsets' => [
+                    'production-information' => 'Información de producción',
+                    'costing-information'    => 'Información de costos',
+                ],
+
+                'entries' => [
+                    'default-capacity' => 'Capacidad predeterminada',
+                    'time-efficiency'  => 'Eficiencia del tiempo',
+                    'oee-target'       => 'Objetivo OEE',
+                    'costs-per-hour'   => 'Costo por hora',
+                    'cost-suffix'      => 'por centro de trabajo',
+                    'setup-time'       => 'Tiempo de preparación',
+                    'cleanup-time'     => 'Tiempo de limpieza',
+                    'time-suffix'      => 'minutos',
+                ],
+            ],
+
+            'description' => [
+                'title'   => 'Descripción',
+                'entries' => [
+                    'note' => 'Descripción',
+                ],
+            ],
+
+            'specific-capacity' => [
+                'title'   => 'Capacidades específicas',
+                'columns' => [
+                    'product'      => 'Producto',
+                    'product-uom'  => 'UOM',
+                    'capacity'     => 'Capacidad',
+                    'setup-time'   => 'Tiempo de preparación',
+                    'cleanup-time' => 'Tiempo de limpieza',
+                ],
+            ],
+
+            'record-information' => [
+                'title' => 'Información del registro',
+
+                'entries' => [
+                    'created-by'   => 'Creado por',
+                    'created-at'   => 'Creado el',
+                    'last-updated' => 'Última actualización',
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/create-work-center.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/create-work-center.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Centro de trabajo creado',
+        'body'  => 'El centro de trabajo ha sido creado correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/edit-work-center.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/edit-work-center.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Centro de trabajo actualizado',
+        'body'  => 'El centro de trabajo ha sido actualizado correctamente.',
+    ],
+
+    'header-actions' => [
+        'delete' => [
+            'notification' => [
+                'title' => 'Centro de trabajo archivado',
+                'body'  => 'El centro de trabajo ha sido archivado correctamente.',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/list-work-centers.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/list-work-centers.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'header-actions' => [
+        'create' => [
+            'label'        => 'Nuevo centro de trabajo',
+            'notification' => [
+                'title' => 'Centro de trabajo creado',
+                'body'  => 'El centro de trabajo ha sido creado correctamente.',
+            ],
+        ],
+    ],
+
+    'tabs' => [
+        'all'      => 'Todos',
+        'archived' => 'Archivados',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/manage-operations.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/manage-operations.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'title' => 'Operaciones',
+
+    'header-actions' => [
+        'create' => [
+            'label' => 'Nueva operación',
+
+            'notification' => [
+                'title' => 'Operación creada',
+                'body'  => 'La operación ha sido creada correctamente.',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/view-work-center.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/configurations/resources/work-center/pages/view-work-center.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'header-actions' => [
+        'delete' => [
+            'notification' => [
+                'title' => 'Centro de trabajo archivado',
+                'body'  => 'El centro de trabajo ha sido archivado correctamente.',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Operaciones',
+        'group' => 'Fabricación',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/cancel.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/cancel.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'label' => 'Cancelar',
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación cancelada',
+            'body'  => 'La orden de fabricación ha sido cancelada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/confirm.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/confirm.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'label' => 'Confirmar',
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación confirmada',
+            'body'  => 'La orden de fabricación ha sido confirmada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/done.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/done.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'label'         => 'Producir todo',
+    'partial-label' => 'Producir',
+
+    'modal' => [
+        'consumption-warning' => [
+            'heading'     => 'Advertencia de consumo',
+            'description' => 'Algunos productos se consumieron en cantidad distinta a la esperada. ¿Desea validar la orden de fabricación con las cantidades actuales?',
+
+            'form' => [
+                'product'    => 'Producto',
+                'to-consume' => 'A consumir',
+                'consumed'   => 'Consumido',
+                'uom'        => 'Unidad de medida',
+            ],
+
+            'actions' => [
+                'confirm' => [
+                    'label' => 'Confirmar',
+                ],
+
+                'set-quantities' => [
+                    'label' => 'Establecer cantidades y confirmar',
+                ],
+            ],
+        ],
+
+        'produced-warning' => [
+            'heading'     => 'La cantidad producida es distinta a la esperada',
+            'description' => 'La cantidad producida es distinta a la esperada. ¿Desea confirmar la orden de fabricación con la cantidad actual?',
+        ],
+    ],
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación completada',
+            'body'  => 'La orden de fabricación ha sido completada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/plan.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/plan.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'label' => 'Planificar',
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación planificada',
+            'body'  => 'La orden de fabricación ha sido planificada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/print/print-labels.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/print/print-labels.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'label' => 'Imprimir etiquetas',
+
+    'form' => [
+        'fields' => [
+            'quantity'      => 'Cantidad',
+            'format'        => 'Formato',
+            'quantity-type' => 'Cantidad a imprimir',
+
+            'quantity-type-options' => [
+                'operation' => 'Cantidad de operación',
+                'custom'    => 'Cantidad personalizada',
+            ],
+
+            'format-options' => [
+                'dymo'       => 'Dymo',
+                '2x7_price'  => '2x7 con precio',
+                '4x7_price'  => '4x7 con precio',
+                '4x12'       => '4x12',
+                '4x12_price' => '4x12 con precio',
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/print/print-mo.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/print/print-mo.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'label' => 'Imprimir OF',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/start.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/start.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'label' => 'Iniciar',
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación iniciada',
+            'body'  => 'La orden de fabricación ha sido iniciada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/unplan.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/actions/unplan.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'label' => 'Desplanificar',
+
+    'notification' => [
+        'success' => [
+            'title' => 'Orden de fabricación desplanificada',
+            'body'  => 'La orden de fabricación ha sido desplanificada correctamente.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order.php
@@ -1,0 +1,193 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Órdenes de fabricación',
+        'group' => 'Operaciones',
+    ],
+
+    'form' => [
+        'sections' => [
+            'general' => [
+                'title'  => 'General',
+                'fields' => [
+                    'product'                => 'Producto',
+                    'quantity'               => 'Cantidad',
+                    'uom'                    => 'UoM',
+                    'bill-of-material'       => 'Lista de materiales',
+                    'scheduled-date'         => 'Fecha programada',
+                    'scheduled-end'          => 'Fin programado',
+                    'responsible'            => 'Responsable',
+                    'to-produce'             => 'A producir',
+                    'to-produce-placeholder' => 'Vista previa de imagen',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'components' => [
+                'title'        => 'Componentes',
+                'add-action'   => 'Agregar una línea',
+                'process-note' => 'Los componentes se generarán conforme se construya el proceso de fabricación.',
+                'columns'      => [
+                    'component'          => 'Producto',
+                    'from'               => 'Desde',
+                    'to-consume'         => 'A consumir',
+                    'to-consume-tooltip' => 'Cantidad disponible insuficiente',
+                    'quantity'           => 'Cantidad',
+                    'uom'                => 'UoM',
+                    'forecast'           => 'Previsión',
+                ],
+            ],
+            'work-orders' => [
+                'title'        => 'Órdenes de trabajo',
+                'add-action'   => 'Agregar una línea',
+                'process-note' => 'Las órdenes de trabajo se generarán después de configurar el proceso de fabricación.',
+                'columns'      => [
+                    'operation'          => 'Operación',
+                    'work-center'        => 'Centro de trabajo',
+                    'product'            => 'Producto',
+                    'quantity-remaining' => 'Cantidad restante',
+                    'quantity-produced'  => 'Cantidad producida',
+                    'start'              => 'Inicio',
+                    'end'                => 'Fin',
+                    'expected-duration'  => 'Duración esperada',
+                    'real-duration'      => 'Duración real',
+                    'status'             => 'Estado',
+                    'lot-serial'         => 'Lote/Serie',
+                ],
+            ],
+            'by-products' => [
+                'title'        => 'Subproductos',
+                'process-note' => 'Los subproductos se generarán conforme se construya el proceso de fabricación.',
+                'columns'      => [
+                    'product'    => 'Producto',
+                    'to'         => 'Hacia',
+                    'to-produce' => 'A producir',
+                    'uom'        => 'UoM',
+                ],
+            ],
+            'miscellaneous' => [
+                'title'  => 'Varios',
+                'fields' => [
+                    'operation-type'             => 'Tipo de operación',
+                    'source'                     => 'Origen',
+                    'finished-products-location' => 'Ubicación de productos terminados',
+                    'company'                    => 'Empresa',
+                ],
+            ],
+        ],
+    ],
+
+    'table' => [
+        'columns' => [
+            'reference'              => 'Referencia',
+            'start'                  => 'Inicio',
+            'end'                    => 'Fin',
+            'deadline'               => 'Fecha límite',
+            'product'                => 'Producto',
+            'lot-serial-number'      => 'Número de lote/serie',
+            'bill-of-material'       => 'Lista de materiales',
+            'source'                 => 'Origen',
+            'responsible'            => 'Responsable',
+            'mo-readiness'           => 'Disponibilidad OF',
+            'component-status'       => 'Estado de componentes',
+            'quantity'               => 'Cantidad',
+            'uom'                    => 'UoM',
+            'consumption-efficiency' => 'Eficiencia de consumo',
+            'expected-duration'      => 'Duración esperada',
+            'real-duration'          => 'Duración real',
+            'company'                => 'Empresa',
+            'state'                  => 'Estado',
+        ],
+        'groups' => [
+            'state'            => 'Estado',
+            'product'          => 'Producto',
+            'bill-of-material' => 'Lista de materiales',
+            'responsible'      => 'Responsable',
+            'deadline'         => 'Fecha límite',
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'general' => [
+                'title'   => 'General',
+                'entries' => [
+                    'product'                  => 'Producto',
+                    'scheduled-date'           => 'Fecha programada',
+                    'responsible'              => 'Responsable',
+                    'quantity'                 => 'Cantidad',
+                    'uom'                      => 'UoM',
+                    'bill-of-material'         => 'Lista de materiales',
+                    'operation-type'           => 'Tipo de operación',
+                    'consumption-efficiency'   => 'Eficiencia de consumo',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'components' => [
+                'title'        => 'Componentes',
+                'process-note' => 'Los componentes estarán disponibles después de configurar el proceso de fabricación.',
+                'columns'      => [
+                    'component' => 'Componente',
+                    'quantity'  => 'Cantidad',
+                    'uom'       => 'UoM',
+                ],
+            ],
+            'work-orders' => [
+                'title'        => 'Órdenes de trabajo',
+                'process-note' => 'Las órdenes de trabajo estarán disponibles después de configurar el proceso de fabricación.',
+                'columns'      => [
+                    'operation'          => 'Operación',
+                    'work-center'        => 'Centro de trabajo',
+                    'product'            => 'Producto',
+                    'quantity-remaining' => 'Cantidad restante',
+                    'expected-duration'  => 'Duración esperada',
+                    'real-duration'      => 'Duración real',
+                    'lot-serial'         => 'Lote/Serie',
+                    'start'              => 'Inicio',
+                    'end'                => 'Fin',
+                ],
+            ],
+            'by-products' => [
+                'title'        => 'Subproductos',
+                'process-note' => 'Los subproductos estarán disponibles después de configurar el proceso de fabricación.',
+                'columns'      => [
+                    'product'    => 'Producto',
+                    'to'         => 'Hacia',
+                    'to-produce' => 'A producir',
+                    'uom'        => 'UoM',
+                ],
+            ],
+            'miscellaneous' => [
+                'title'   => 'Varios',
+                'entries' => [
+                    'operation-type'             => 'Tipo de operación',
+                    'source'                     => 'Origen',
+                    'finished-products-location' => 'Ubicación de productos terminados',
+                    'company'                    => 'Empresa',
+                ],
+            ],
+        ],
+    ],
+
+    'pages' => [
+        'shared' => [
+            'header-actions' => [
+                'confirm' => [
+                    'label'        => 'Confirmar',
+                    'notification' => [
+                        'title' => 'Orden de fabricación confirmada',
+                    ],
+                ],
+
+                'cancel' => [
+                    'label'        => 'Cancelar',
+                    'notification' => [
+                        'title' => 'Orden de fabricación cancelada',
+                    ],
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/create-manufacturing-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/create-manufacturing-order.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'title'        => 'Crear orden de fabricación',
+
+    'notification' => [
+        'title' => 'Orden de fabricación creada',
+        'body'  => 'La orden de fabricación ha sido creada correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/edit-manufacturing-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/edit-manufacturing-order.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'title' => 'Editar orden de fabricación',
+
+    'header-actions' => [
+        'print' => [
+            'label' => 'Imprimir',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/list-manufacturing-orders.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/list-manufacturing-orders.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'title'        => 'Órdenes de fabricación',
+
+    'header-actions' => [
+        'create' => [
+            'label' => 'Crear orden de fabricación',
+        ],
+    ],
+
+    'tabs' => [
+        'todo'        => 'Por hacer',
+        'done'        => 'Realizado',
+        'cancelled'   => 'Cancelado',
+        'planned'     => 'Planificado',
+        'draft'       => 'Borrador',
+        'confirmed'   => 'Confirmado',
+        'in-progress' => 'En curso',
+        'to-close'    => 'Por cerrar',
+        'mo-pending'  => 'OF pendiente',
+        'mo-ready'    => 'OF lista',
+        'my-mos'      => 'Mis OFs',
+        'late'        => 'Con retraso',
+    ],
+
+    'notification' => [
+        'title' => 'Orden de fabricación creada',
+        'body'  => 'La orden de fabricación ha sido creada correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/manage-transfers.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/manage-transfers.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Transferencias',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/overview-manufacturing-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/overview-manufacturing-order.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'title'   => 'Resumen',
+    'summary' => [
+        'free-to-use' => 'Libre de uso',
+    ],
+    'status' => [
+        'ready'     => 'Listo',
+        'available' => 'Disponible',
+        'waiting'   => 'En espera',
+    ],
+    'receipt' => [
+        'expected' => 'Esperado el :date',
+    ],
+    'table' => [
+        'columns' => [
+            'product'               => 'Producto',
+            'status'                => 'Estado',
+            'quantity'              => 'Cantidad',
+            'free-to-use-on-hand'   => 'Libre de uso / En existencia',
+            'reserved'              => 'Reservado',
+            'receipt'               => 'Recepción',
+            'unit-cost'             => 'Costo unitario',
+            'mo-cost'               => 'Costo OF',
+            'bom-cost'              => 'Costo LdM',
+            'real-cost'             => 'Costo real',
+        ],
+        'sections' => [
+            'operations' => 'Operaciones',
+        ],
+        'rows' => [
+            'minutes' => 'Minutos',
+        ],
+        'footer' => [
+            'unit-cost' => 'Costo unitario',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/view-manufacturing-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/manufacturing-order/pages/view-manufacturing-order.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'title' => 'Ver orden de fabricación',
+
+    'header-actions' => [
+        'print' => [
+            'label' => 'Imprimir',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order.php
@@ -1,0 +1,161 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Órdenes de trabajo',
+        'group' => 'Operaciones',
+    ],
+
+    'form' => [
+        'sections' => [
+            'general' => [
+                'title'  => 'General',
+                'fields' => [
+                    'work-order'          => 'Orden de trabajo',
+                    'work-center'         => 'Centro de trabajo',
+                    'product'             => 'Producto',
+                    'quantity'            => 'Cantidad',
+                    'manufacturing-order' => 'Orden de fabricación',
+                    'lot-serial'          => 'Número de lote/serie',
+                    'start-date'          => 'Fecha de inicio',
+                    'end-date'            => 'Fecha de finalización',
+                    'date-range-separator'=> 'a',
+                    'expected-duration'   => 'Duración esperada',
+                    'duration-suffix'     => 'minutos',
+                    'real-duration'       => 'Duración real',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'time-tracking' => [
+                'title'      => 'Seguimiento de tiempo',
+                'add-action' => 'Agregar una línea',
+                'columns'    => [
+                    'user'         => 'Usuario',
+                    'duration'     => 'Duración',
+                    'start-date'   => 'Fecha de inicio',
+                    'end-date'     => 'Fecha de finalización',
+                    'productivity' => 'Productividad',
+                ],
+                'footer' => [
+                    'real-duration' => 'Duración real',
+                ],
+            ],
+            'components' => [
+                'title'      => 'Componentes',
+                'add-action' => 'Agregar una línea',
+                'columns'    => [
+                    'product'    => 'Producto',
+                    'to-consume' => 'A consumir',
+                    'quantity'   => 'Cantidad',
+                    'uom'        => 'UoM',
+                ],
+            ],
+            'work-instruction' => [
+                'title'   => 'Instrucción de trabajo',
+                'entries' => [
+                    'operation' => 'Operación',
+                    'worksheet' => 'Hoja de trabajo',
+                ],
+            ],
+            'blocked-by' => [
+                'title'  => 'Bloqueado por',
+                'fields' => [
+                    'work-orders' => 'Órdenes de trabajo',
+                ],
+            ],
+        ],
+    ],
+
+    'table' => [
+        'columns' => [
+            'operation'           => 'Operación',
+            'work-center'         => 'Centro de trabajo',
+            'manufacturing-order' => 'Orden de fabricación',
+            'product'             => 'Producto',
+            'quantity-remaining'  => 'Cantidad restante',
+            'lot-serial'          => 'Lote/Serie',
+            'start'               => 'Inicio',
+            'end'                 => 'Fin',
+            'expected-duration'   => 'Duración esperada',
+            'real-duration'       => 'Duración real',
+            'status'              => 'Estado',
+        ],
+        'groups' => [
+            'status'              => 'Estado',
+            'work-center'         => 'Centro de trabajo',
+            'manufacturing-order' => 'Orden de fabricación',
+            'product'             => 'Producto',
+            'start'               => 'Inicio',
+            'end'                 => 'Fin',
+        ],
+        'filters' => [
+            'work-order'          => 'Orden de trabajo',
+            'status'              => 'Estado',
+            'operation'           => 'Operación',
+            'work-center'         => 'Centro de trabajo',
+            'manufacturing-order' => 'Orden de fabricación',
+            'product'             => 'Producto',
+            'start'               => 'Inicio',
+            'end'                 => 'Fin',
+            'created-at'          => 'Creado el',
+            'updated-at'          => 'Actualizado el',
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'general' => [
+                'title'   => 'General',
+                'entries' => [
+                    'work-order'          => 'Orden de trabajo',
+                    'work-center'         => 'Centro de trabajo',
+                    'product'             => 'Producto',
+                    'quantity'            => 'Cantidad',
+                    'manufacturing-order' => 'Orden de fabricación',
+                    'lot-serial'          => 'Número de lote/serie',
+                    'start-date'          => 'Fecha de inicio',
+                    'end-date'            => 'Fecha de finalización',
+                    'expected-duration'   => 'Duración esperada',
+                    'real-duration'       => 'Duración real',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'time-tracking' => [
+                'title'  => 'Seguimiento de tiempo',
+                'footer' => [
+                    'real-duration' => 'Duración real',
+                ],
+            ],
+            'components' => [
+                'title' => 'Componentes',
+            ],
+            'work-instruction' => [
+                'title'   => 'Instrucción de trabajo',
+                'entries' => [
+                    'operation' => 'Operación',
+                    'worksheet' => 'Hoja de trabajo',
+                ],
+            ],
+            'blocked-by' => [
+                'title'   => 'Bloqueado por',
+                'columns' => [
+                    'work-order'  => 'Orden de trabajo',
+                    'work-center' => 'Centro de trabajo',
+                    'status'      => 'Estado',
+                ],
+            ],
+        ],
+    ],
+
+    'pages' => [
+        'list' => [
+            'header-actions' => [
+                'create' => [
+                    'label' => 'Nueva orden de trabajo',
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/edit-work-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/edit-work-order.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Editar orden de trabajo',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/list-work-orders.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/list-work-orders.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'title' => 'Órdenes de trabajo',
+
+    'tabs' => [
+        'todo'      => 'Por hacer',
+        'done'      => 'Realizado',
+        'draft'     => 'Borrador',
+        'cancelled' => 'Cancelado',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/view-work-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/operations/resources/work-order/pages/view-work-order.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Ver orden de trabajo',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Productos',
+        'group' => 'Fabricación',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material.php
@@ -1,0 +1,238 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Listas de materiales',
+    ],
+
+    'form' => [
+        'sections' => [
+            'general' => [
+                'title'  => 'General',
+                'fields' => [
+                    'reference'             => 'Referencia',
+                    'reference-placeholder' => 'ej. LdM-001',
+                    'product'               => 'Producto',
+                    'product-variant'       => 'Variante del producto',
+                    'quantity'              => 'Cantidad',
+                    'uom'                   => 'UOM',
+                    'operation-type'        => 'Tipo de operación',
+                    'company'               => 'Empresa',
+                    'type'                  => 'Tipo de LdM',
+                ],
+            ],
+            'miscellaneous' => [
+                'title'  => 'Varios',
+                'fields' => [
+                    'kit-information'                         => 'Información del kit',
+                    'kit-information-content'                 => 'Una LdM de tipo kit se usa para agrupar componentes en transferencias o ventas, en lugar de producirse mediante una orden de fabricación.',
+                    'manufacturing-lead-time'                 => 'Tiempo de entrega de fabricación',
+                    'days-to-prepare-manufacturing-order'     => 'Días para preparar la orden de fabricación',
+                    'days-suffix'                             => 'días',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'components' => [
+                'title'      => 'Componentes',
+                'add-action' => 'Agregar una línea',
+                'columns'    => [
+                    'component'              => 'Componente',
+                    'apply-on-variants'      => 'Aplicar en variantes',
+                    'consumed-in-operation'  => 'Consumido en operación',
+                    'highlight-consumption'  => 'Resaltar consumo',
+                    'quantity'               => 'Cantidad',
+                    'uom'                    => 'Unidad de medida del producto',
+                ],
+                'create-form' => [
+                    'fields' => [
+                        'name'            => 'Nombre',
+                        'type'            => 'Tipo',
+                        'category'        => 'Categoría',
+                        'company'         => 'Empresa',
+                        'uom'             => 'UOM',
+                        'uom-placeholder' => 'UOM',
+                    ],
+                ],
+            ],
+            'operations' => [
+                'title'      => 'Operaciones',
+                'add-action' => 'Agregar una línea',
+                'actions'    => [
+                    'edit'                 => 'Editar operación',
+                    'copy-existing'        => 'Copiar operaciones existentes',
+                    'copy-existing-fields' => [
+                        'operation' => 'Operación',
+                    ],
+                ],
+                'columns'    => [
+                    'operation'        => 'Operación',
+                    'work-center'      => 'Centro de trabajo',
+                    'time-mode'        => 'Cálculo de duración',
+                    'time-mode-batch'  => 'Calculado en el último',
+                    'company'          => 'Empresa',
+                    'apply-on-variants'=> 'Aplicar en variantes',
+                    'duration'         => 'Duración (minutos)',
+                ],
+            ],
+            'by-products' => [
+                'title'      => 'Subproductos',
+                'add-action' => 'Agregar una línea',
+                'columns'    => [
+                    'product'   => 'Subproducto',
+                    'quantity'  => 'Cantidad',
+                    'uom'       => 'Unidad de medida',
+                    'operation' => 'Producido en operación',
+                ],
+            ],
+            'miscellaneous' => [
+                'title'  => 'Varios',
+                'fields' => [
+                    'ready-to-produce'       => 'Preparación para fabricación',
+                    'routing'                => 'Ruta de fabricación',
+                    'consumption'            => 'Consumo flexible',
+                    'operation-dependencies' => 'Dependencias de operaciones',
+                ],
+            ],
+        ],
+    ],
+
+    'table' => [
+        'columns' => [
+            'reference'  => 'Referencia',
+            'product'    => 'Producto',
+            'quantity'   => 'Cantidad',
+            'uom'        => 'UOM',
+            'type'       => 'Tipo de LdM',
+            'company'    => 'Empresa',
+            'deleted-at' => 'Eliminado el',
+            'updated-at' => 'Actualizado el',
+        ],
+        'filters' => [
+            'product' => 'Producto',
+            'type'    => 'Tipo de LdM',
+            'company' => 'Empresa',
+        ],
+        'actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Lista de materiales restaurada',
+                    'body'  => 'La lista de materiales ha sido restaurada correctamente.',
+                ],
+            ],
+            'delete' => [
+                'notification' => [
+                    'title' => 'Lista de materiales archivada',
+                    'body'  => 'La lista de materiales ha sido archivada correctamente.',
+                ],
+            ],
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Lista de materiales eliminada',
+                        'body'  => 'La lista de materiales ha sido eliminada permanentemente.',
+                    ],
+                    'error' => [
+                        'title' => 'No se pudo eliminar la lista de materiales',
+                        'body'  => 'La lista de materiales no puede eliminarse porque está en uso.',
+                    ],
+                ],
+            ],
+        ],
+        'bulk-actions' => [
+            'restore' => [
+                'notification' => [
+                    'title' => 'Listas de materiales restauradas',
+                    'body'  => 'Las listas de materiales seleccionadas han sido restauradas correctamente.',
+                ],
+            ],
+            'delete' => [
+                'notification' => [
+                    'title' => 'Listas de materiales archivadas',
+                    'body'  => 'Las listas de materiales seleccionadas han sido archivadas correctamente.',
+                ],
+            ],
+            'force-delete' => [
+                'notification' => [
+                    'success' => [
+                        'title' => 'Listas de materiales eliminadas',
+                        'body'  => 'Las listas de materiales seleccionadas han sido eliminadas permanentemente.',
+                    ],
+                    'error' => [
+                        'title' => 'No se pudieron eliminar las listas de materiales',
+                        'body'  => 'Una o más listas de materiales seleccionadas están en uso.',
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'general' => [
+                'title'   => 'Información general',
+                'entries' => [
+                    'reference'      => 'Referencia',
+                    'product'        => 'Producto',
+                    'product-variant'=> 'Variante del producto',
+                    'quantity'       => 'Cantidad',
+                    'uom'            => 'UOM',
+                    'operation-type' => 'Tipo de operación',
+                    'company'        => 'Empresa',
+                    'type'           => 'Tipo de LdM',
+                ],
+            ],
+            'record-information' => [
+                'title'   => 'Información del registro',
+                'entries' => [
+                    'created-by'   => 'Creado por',
+                    'created-at'   => 'Creado el',
+                    'last-updated' => 'Última actualización',
+                ],
+            ],
+        ],
+        'tabs' => [
+            'components' => [
+                'title'   => 'Componentes',
+                'entries' => [
+                    'component' => 'Componente',
+                    'operation' => 'Operación',
+                    'quantity'  => 'Cantidad',
+                    'uom'       => 'Unidad de medida del producto',
+                ],
+            ],
+            'operations' => [
+                'title'   => 'Operaciones',
+                'entries' => [
+                    'operation'   => 'Operación',
+                    'work-center' => 'Centro de trabajo',
+                    'time-mode'   => 'Cálculo de duración',
+                    'duration'    => 'Duración (minutos)',
+                ],
+            ],
+            'by-products' => [
+                'title'   => 'Subproductos',
+                'entries' => [
+                    'product'   => 'Subproducto',
+                    'quantity'  => 'Cantidad',
+                    'uom'       => 'Unidad de medida',
+                    'operation' => 'Producido en operación',
+                ],
+            ],
+            'miscellaneous' => [
+                'title'   => 'Varios',
+                'entries' => [
+                    'kit-information'                         => 'Información del kit',
+                    'kit-information-content'                 => 'Una LdM de tipo kit se usa para agrupar componentes en transferencias o ventas, en lugar de producirse mediante una orden de fabricación.',
+                    'ready-to-produce'                        => 'Preparación para fabricación',
+                    'routing'                                 => 'Ruta de fabricación',
+                    'consumption'                             => 'Consumo flexible',
+                    'operation-dependencies'                  => 'Dependencias de operaciones',
+                    'manufacturing-lead-time'                 => 'Tiempo de entrega de fabricación',
+                    'days-to-prepare-manufacturing-order'     => 'Días para preparar la orden de fabricación',
+                    'days-suffix'                             => 'días',
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/bill-of-material-overview.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/bill-of-material-overview.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Vista general',
+    ],
+
+    'title' => 'Vista general',
+
+    'heading' => 'Vista general',
+
+    'filters' => [
+        'quantity' => 'Cantidad',
+        'variant'  => 'Variante',
+    ],
+
+    'summary' => [
+        'free-to-use' => 'Libre para usar',
+        'on-hand'     => 'En existencias',
+        'total-cost'  => 'Costo total',
+    ],
+
+    'table' => [
+        'columns' => [
+            'product'      => 'Producto',
+            'quantity'     => 'Cantidad',
+            'lead-time'    => 'Tiempo de entrega',
+            'route'        => 'Ruta',
+            'bom-cost'     => 'Costo de LdM',
+            'product-cost' => 'Costo del producto',
+        ],
+        'sections' => [
+            'operations' => 'Operaciones',
+        ],
+        'rows' => [
+            'days'    => 'días',
+            'minutes' => 'Minutos',
+        ],
+        'footer' => [
+            'unit-cost' => 'Costo unitario',
+        ],
+    ],
+
+    'by-products' => [
+        'title'   => 'Subproductos',
+        'columns' => [
+            'product'  => 'Subproducto',
+            'quantity' => 'Cantidad',
+            'uom'      => 'Unidad de medida',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/create-bill-of-material.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/create-bill-of-material.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Lista de materiales creada',
+        'body'  => 'La lista de materiales ha sido creada correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/edit-bill-of-material.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/edit-bill-of-material.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'notification' => [
+        'title' => 'Lista de materiales actualizada',
+        'body'  => 'La lista de materiales ha sido actualizada correctamente.',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/list-bills-of-material.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/bill-of-material/pages/list-bills-of-material.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'header-actions' => [
+        'create' => [
+            'label'        => 'Nueva lista de materiales',
+            'notification' => [
+                'title' => 'Lista de materiales creada',
+                'body'  => 'La lista de materiales ha sido creada correctamente.',
+            ],
+        ],
+    ],
+
+    'tabs' => [
+        'all'      => 'Todas',
+        'archived' => 'Archivadas',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/product/pages/bill-of-materials.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/product/pages/bill-of-materials.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'navigation' => [
+        'title' => 'Listas de materiales',
+    ],
+
+    'header-actions' => [
+        'create' => [
+            'label' => 'Crear lista de materiales',
+
+            'notifications' => [
+                'success' => [
+                    'title'   => 'Lista de materiales creada',
+                    'message' => 'La lista de materiales ha sido creada correctamente.',
+                ],
+            ],
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/product/pages/list-products.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/products/resources/product/pages/list-products.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'tabs' => [
+        'components' => 'Componentes',
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/settings/pages/manage-operations.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/settings/pages/manage-operations.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'title' => 'Gestionar operaciones',
+
+    'form' => [
+        'enable-work-orders' => [
+            'label'       => 'Órdenes de trabajo',
+            'helper-text' => 'Ejecutar operaciones en centros de trabajo designados.',
+            'link-text'   => 'Configurar centros de trabajo',
+        ],
+
+        'enable-work-order-dependencies' => [
+            'label'       => 'Dependencias de órdenes de trabajo',
+            'helper-text' => 'Definir el orden en que deben procesarse las órdenes de trabajo. Activar esta función desde la pestaña Varios de cada LdM.',
+        ],
+
+        'enable-byproducts' => [
+            'label'       => 'Subproductos',
+            'helper-text' => 'Generar subproductos durante la producción (A + B → C + D).',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/settings/pages/manage-planning.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/filament/clusters/settings/pages/manage-planning.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'title' => 'Gestionar planificación',
+
+    'form' => [
+        'manufacturing-lead-time' => [
+            'label'       => 'Tiempo de entrega de fabricación',
+            'helper-text' => 'Planificar las órdenes de fabricación con anticipación para evitar retrasos.',
+        ],
+    ],
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/bill-of-material.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/bill-of-material.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Lista de materiales',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/operation.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/operation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Operación',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/order.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Orden de fabricación',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/unbuild-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/unbuild-order.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Orden de desarmado',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/work-center.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/work-center.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Centro de trabajo',
+];

--- a/plugins/webkul/manufacturing/resources/lang/es/models/work-order.php
+++ b/plugins/webkul/manufacturing/resources/lang/es/models/work-order.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'title' => 'Orden de trabajo',
+];


### PR DESCRIPTION
Adds the complete Spanish (`es`) locale for the **manufacturing** plugin: 61 files covering app strings, models, enums, the configurations cluster (work-center + operation), the operations cluster (manufacturing-order + work-order + 8 actions like plan/unplan/start/confirm/cancel/done/print-MO/print-labels), the products cluster (bill-of-material with its overview, list, create, edit pages plus product-level BoM pages), and the settings pages.

**Style guidelines (consistent with `products` PR #1248 and `inventories` PR #1249):**
- Neutral / international Spanish, impersonal register (infinitives, no `tú`/`usted`) — applied to settings page helper texts from the start
- Sentence case for multi-word values
- Manufacturing-specific glossary: `Lista de materiales` (BoM, with `LdM` acronym), `Orden de fabricación` (MO, with `OF` acronym), `Orden de trabajo`, `Centro de trabajo`, `Orden de desarmado`, `Subensamble`, `Hoja de trabajo`, `Subproductos`, `Permitido/Bloqueado` (consumption policies), `Terminado` (work-order finished, distinct from `Realizado`/Done), `Por cerrar`, `Tiempo de preparación/limpieza`, `Eficiencia del tiempo`, `Objetivo OEE`, `Centros de trabajo alternativos`, etc.
- Glossary aligned cross-module with `products` and `inventories` PRs
- Placeholders and HTML tags preserved verbatim
- Each `es` file is a byte-for-byte structural clone of its `en/` counterpart

**Note:** `es` is intentionally not added to `config/app.php` `supported_locales` in this PR. A dedicated follow-up PR will activate the locale once the `products`, `inventories`, and `manufacturing` translation PRs are merged.
