### PR TITLE
Refresh caches on plugin install/uninstall 

### DIFF
--- a/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
+++ b/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
@@ -173,6 +173,10 @@ class InstallCommand extends Command
 
         $this->regenerateAdminPanelPermissions();
 
+        $this->info('⚙️ Refreshing application caches so the plugin navigation is reflected...');
+
+        Package::refreshPluginCaches();
+
         $this->info("🎉 Package <comment>{$this->package->shortName()}</comment> has been installed!");
     }
 
@@ -470,39 +474,7 @@ class InstallCommand extends Command
 
     protected function getPhpExecutablePath(): string
     {
-        $phpPath = trim(shell_exec('which php 2>/dev/null') ?: '');
-
-        if (
-            $phpPath
-            && file_exists($phpPath)
-        ) {
-            return $phpPath;
-        }
-
-        $phpPath = PHP_BINARY;
-
-        if (strpos($phpPath, 'fpm') !== false) {
-            $phpPath = str_replace('fpm', '', $phpPath);
-        }
-
-        if (file_exists($phpPath)) {
-            return $phpPath;
-        }
-
-        $commonPaths = [
-            '/usr/local/bin/php',
-            '/usr/bin/php',
-            '/opt/homebrew/bin/php',
-            '/Users/'.get_current_user().'/Library/Application Support/Herd/bin/php',
-        ];
-
-        foreach ($commonPaths as $path) {
-            if (file_exists($path)) {
-                return $path;
-            }
-        }
-
-        return 'php';
+        return Package::phpBinaryPath();
     }
 
     protected function buildTimeoutCommand(int $seconds, string $command): string

--- a/plugins/webkul/plugin-manager/src/Console/Commands/UninstallCommand.php
+++ b/plugins/webkul/plugin-manager/src/Console/Commands/UninstallCommand.php
@@ -68,6 +68,10 @@ class UninstallCommand extends Command
         if ($this->endWith) {
             ($this->endWith)($this);
         }
+
+        $this->info('⚙️ Refreshing application caches so the plugin navigation is updated...');
+
+        Package::refreshPluginCaches();
     }
 
     protected function dropTables(): void

--- a/plugins/webkul/plugin-manager/src/Filament/Resources/PluginResource.php
+++ b/plugins/webkul/plugin-manager/src/Filament/Resources/PluginResource.php
@@ -372,6 +372,8 @@ class PluginResource extends Resource
                 }
             });
 
+        Package::refreshPluginCaches();
+
         if (empty($errors)) {
             Notification::make()
                 ->title(__('plugin-manager::filament/resources/plugin.notifications.uninstalled.title'))
@@ -414,39 +416,7 @@ class PluginResource extends Resource
 
     protected static function getPhpExecutablePath(): string
     {
-        $phpPath = trim(shell_exec('which php 2>/dev/null') ?: '');
-
-        if (
-            $phpPath
-            && file_exists($phpPath)
-        ) {
-            return $phpPath;
-        }
-
-        $phpPath = PHP_BINARY;
-
-        if (strpos($phpPath, 'fpm') !== false) {
-            $phpPath = str_replace('fpm', '', $phpPath);
-        }
-
-        if (file_exists($phpPath)) {
-            return $phpPath;
-        }
-
-        $commonPaths = [
-            '/usr/local/bin/php',
-            '/usr/bin/php',
-            '/opt/homebrew/bin/php',
-            '/Users/'.get_current_user().'/Library/Application Support/Herd/bin/php',
-        ];
-
-        foreach ($commonPaths as $path) {
-            if (file_exists($path)) {
-                return $path;
-            }
-        }
-
-        return 'php';
+        return Package::phpBinaryPath();
     }
 
     protected static function buildTimeoutCommand(int $seconds, string $command): string

--- a/plugins/webkul/plugin-manager/src/Package.php
+++ b/plugins/webkul/plugin-manager/src/Package.php
@@ -3,9 +3,11 @@
 namespace Webkul\PluginManager;
 
 use Exception;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Spatie\LaravelPackageTools\Package as BasePackage;
+use Throwable;
 use Webkul\PluginManager\Console\Commands\InstallCommand;
 use Webkul\PluginManager\Console\Commands\UninstallCommand;
 use Webkul\PluginManager\Models\Plugin;
@@ -192,6 +194,64 @@ class Package extends BasePackage
         }
 
         return static::$plugins[$name] ??= Plugin::where('name', $name)->first();
+    }
+
+   
+    public static function refreshPluginCaches(): void
+    {
+        try {
+            Artisan::call('optimize:clear');
+
+           if (app()->isProduction()) {
+                static::rebuildCachesInBackground();
+            }
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+
+    protected static function rebuildCachesInBackground(): void
+    {
+        if (! app()->isProduction() || PHP_OS_FAMILY === 'Windows') {
+            return;
+        }
+
+        $command = sprintf(
+            '%s %s optimize > /dev/null 2>&1 &',
+            escapeshellarg(static::phpBinaryPath()),
+            escapeshellarg(base_path('artisan'))
+        );
+
+        exec($command);
+    }
+
+  
+    public static function phpBinaryPath(): string
+    {
+        $php = trim((string) @shell_exec('which php 2>/dev/null'));
+
+        if ($php !== '' && is_file($php)) {
+            return $php;
+        }
+
+        if (! str_contains(PHP_BINARY, 'fpm') && is_file(PHP_BINARY)) {
+            return PHP_BINARY;
+        }
+
+        $candidates = [
+            '/usr/local/bin/php',
+            '/usr/bin/php',
+            '/opt/homebrew/bin/php',
+            '/Users/'.get_current_user().'/Library/Application Support/Herd/bin/php',
+        ];
+
+        foreach ($candidates as $path) {
+            if (is_file($path)) {
+                return $path;
+            }
+        }
+
+        return 'php';
     }
 
     public static function isPluginInstalled(string $name): bool


### PR DESCRIPTION

After running php artisan optimize, installing or uninstalling a plugin from the UI didn't update the navigation. Filament v5 caches each panel's discovered components (bootstrap/cache/filament/panels/*.php) during optimize, and plugins only register their resources/routes while is_installed is true. Since install/uninstall only flips the DB flag, the cached components stayed frozen until a manual php artisan optimize:clear.

Fix

Added Package::refreshPluginCaches(), called from every install/uninstall path (InstallCommand, UninstallCommand, and the in-request PluginResource::uninstallPlugin):
- Always runs optimize:clear so the new plugin's navigation appears immediately (safe in local — no surprise cached config/routes).
- In production only, rebuilds the caches via a detached background php artisan optimize so performance is restored without blocking the request.
