### PR TITLE
Fix BOM cost calculation across units of measure

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,9 @@
         <testsuite name="InventoryFeature">
             <directory>plugins/webkul/inventories/tests/Feature</directory>
         </testsuite>
+        <testsuite name="ManufacturingUnit">
+            <directory>plugins/webkul/manufacturing/tests/Unit</directory>
+        </testsuite>
         <testsuite name="SaleFeature">
             <directory>plugins/webkul/sales/tests/Feature</directory>
         </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,9 @@
         <testsuite name="ManufacturingUnit">
             <directory>plugins/webkul/manufacturing/tests/Unit</directory>
         </testsuite>
+        <testsuite name="ManufacturingFeature">
+            <directory>plugins/webkul/manufacturing/tests/Feature</directory>
+        </testsuite>
         <testsuite name="SaleFeature">
             <directory>plugins/webkul/sales/tests/Feature</directory>
         </testsuite>

--- a/plugins/webkul/inventories/src/InventoryServiceProvider.php
+++ b/plugins/webkul/inventories/src/InventoryServiceProvider.php
@@ -14,6 +14,7 @@ use Webkul\Inventory\Models\Move;
 use Webkul\Inventory\Models\MoveLine;
 use Webkul\Inventory\Models\ProductQuantity;
 use Webkul\Inventory\Models\Route;
+use Webkul\Inventory\Observers\ProductObserver;
 use Webkul\PluginManager\Console\Commands\InstallCommand;
 use Webkul\PluginManager\Console\Commands\UninstallCommand;
 use Webkul\PluginManager\Package;
@@ -139,6 +140,8 @@ class InventoryServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $this->contributeProductSchema();
+
+        Product::observe(ProductObserver::class);
     }
 
     protected function contributeProductSchema(): void

--- a/plugins/webkul/inventories/src/Observers/ProductObserver.php
+++ b/plugins/webkul/inventories/src/Observers/ProductObserver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webkul\Inventory\Observers;
+
+use Illuminate\Validation\ValidationException;
+use Webkul\Inventory\Models\Move;
+use Webkul\PluginManager\Package;
+use Webkul\Product\Models\Product;
+
+class ProductObserver
+{
+    public function updating(Product $product): void
+    {
+        if (! Package::isPluginInstalled('inventories')
+            || ! $product->isDirty('uom_id')) {
+            return;
+        }
+
+        if (Move::query()->where('product_id', $product->getKey())->exists()) {
+            throw ValidationException::withMessages([
+                'uom_id' => __('You cannot change the unit of measure as there are already stock moves for this product. If you want to change the unit of measure, archive this product and create a new one.'),
+            ]);
+        }
+    }
+}

--- a/plugins/webkul/manufacturing/resources/views/filament/clusters/operations/resources/manufacturing-order/pages/overview-manufacturing-order.blade.php
+++ b/plugins/webkul/manufacturing/resources/views/filament/clusters/operations/resources/manufacturing-order/pages/overview-manufacturing-order.blade.php
@@ -9,6 +9,21 @@
     @endphp
 
     <div class="space-y-6">
+        @if ($this->hasIncompatibleComponentCostUom())
+            <x-filament::section
+                icon="heroicon-o-exclamation-triangle"
+                icon-color="warning"
+            >
+                <x-slot name="heading">
+                    {{ __('Some component costs are unavailable') }}
+                </x-slot>
+
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('A component unit of measure does not belong to the same category as the product cost unit. Update the product or BOM component unit of measure to calculate its cost.') }}
+                </p>
+            </x-filament::section>
+        @endif
+
         <x-filament::section>
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-white/5">

--- a/plugins/webkul/manufacturing/resources/views/filament/clusters/products/resources/bill-of-material/pages/bill-of-material-overview.blade.php
+++ b/plugins/webkul/manufacturing/resources/views/filament/clusters/products/resources/bill-of-material/pages/bill-of-material-overview.blade.php
@@ -10,6 +10,21 @@
     @endphp
 
     <div class="space-y-6">
+        @if ($this->hasIncompatibleComponentCostUom())
+            <x-filament::section
+                icon="heroicon-o-exclamation-triangle"
+                icon-color="warning"
+            >
+                <x-slot name="heading">
+                    {{ __('Some component costs are unavailable') }}
+                </x-slot>
+
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('A component unit of measure does not belong to the same category as the product cost unit. Update the product or BOM component unit of measure to calculate its cost.') }}
+                </p>
+            </x-filament::section>
+        @endif
+
         <x-filament::section>
             <div class="grid gap-6 lg:grid-cols-3">
                 <div class="space-y-4 lg:col-span-2">

--- a/plugins/webkul/manufacturing/src/Filament/Clusters/Operations/Resources/ManufacturingOrderResource/Pages/OverviewManufacturingOrder.php
+++ b/plugins/webkul/manufacturing/src/Filament/Clusters/Operations/Resources/ManufacturingOrderResource/Pages/OverviewManufacturingOrder.php
@@ -28,10 +28,13 @@ class OverviewManufacturingOrder extends ViewRecord
 
         $this->getRecord()->load([
             'product.uom',
+            'product.uomPO',
             'product.quantities',
             'uom',
             'billOfMaterial',
+            'rawMaterialMoves.uom',
             'rawMaterialMoves.product.uom',
+            'rawMaterialMoves.product.uomPO',
             'rawMaterialMoves.product.quantities',
             'rawMaterialMoves.lines',
             'workOrders.product.uom',
@@ -154,12 +157,15 @@ class OverviewManufacturingOrder extends ViewRecord
 
     public function getComponentUnitCost(Move $move): float
     {
-        return round((float) ($move->product?->cost ?? 0), 2);
+        return round($move->product?->getCostForQuantity(1, $move->uom) ?? 0, 2);
     }
 
     public function getComponentTotalCost(Move $move): float
     {
-        return round($this->getComponentUnitCost($move) * (float) $move->product_uom_qty, 2);
+        return round(
+            $move->product?->getCostForQuantity((float) $move->product_uom_qty, $move->uom) ?? 0,
+            2,
+        );
     }
 
     public function getComponentRealCost(Move $move): float
@@ -170,7 +176,7 @@ class OverviewManufacturingOrder extends ViewRecord
 
         $actualQuantity = (float) ($move->quantity ?: $move->product_uom_qty);
 
-        return round($this->getComponentUnitCost($move) * $actualQuantity, 2);
+        return round($move->product?->getCostForQuantity($actualQuantity, $move->uom) ?? 0, 2);
     }
 
     public function getWorkOrderUnitCost(WorkOrder $workOrder): float
@@ -279,6 +285,12 @@ class OverviewManufacturingOrder extends ViewRecord
 
     public function getParentProductCost(): float
     {
-        return round((float) ($this->getRecord()->product?->cost ?? 0) * (float) $this->getRecord()->quantity, 2);
+        return round(
+            $this->getRecord()->product?->getCostForQuantity(
+                (float) $this->getRecord()->quantity,
+                $this->getRecord()->uom,
+            ) ?? 0,
+            2,
+        );
     }
 }

--- a/plugins/webkul/manufacturing/src/Filament/Clusters/Operations/Resources/ManufacturingOrderResource/Pages/OverviewManufacturingOrder.php
+++ b/plugins/webkul/manufacturing/src/Filament/Clusters/Operations/Resources/ManufacturingOrderResource/Pages/OverviewManufacturingOrder.php
@@ -107,6 +107,13 @@ class OverviewManufacturingOrder extends ViewRecord
             ->values();
     }
 
+    public function hasIncompatibleComponentCostUom(): bool
+    {
+        return $this->getComponentRows()
+            ->contains(fn (Move $move): bool => (bool) $move->product
+                && ! $move->product->isCostUomCompatible($move->uom));
+    }
+
     public function getWorkOrderRows(): Collection
     {
         return $this->getRecord()->workOrders

--- a/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource.php
+++ b/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource.php
@@ -72,6 +72,7 @@ use Webkul\Support\Filament\Forms\Components\Repeater\TableColumn as RepeaterTab
 use Webkul\Support\Filament\Infolists\Components\RepeatableEntry;
 use Webkul\Support\Filament\Infolists\Components\Repeater\TableColumn as InfolistTableColumn;
 use Webkul\Support\Models\Company;
+use Webkul\Support\Models\UOM;
 
 class BillsOfMaterialResource extends Resource
 {
@@ -786,6 +787,8 @@ class BillsOfMaterialResource extends Resource
             ])
             ->schema([
                 Hidden::make('company_id'),
+                Hidden::make('uom_conversion_source_id')
+                    ->dehydrated(false),
                 Select::make('product_id')
                     ->relationship('product', 'name', fn (Builder $query) => $query
                         ->withTrashed()
@@ -839,6 +842,7 @@ class BillsOfMaterialResource extends Resource
                         }
 
                         $set('uom_id', $product->uom_id);
+                        $set('uom_conversion_source_id', $product->uom_id);
                         $set('company_id', $get('../../company_id'));
                     }),
                 TextInput::make('quantity')
@@ -863,6 +867,33 @@ class BillsOfMaterialResource extends Resource
                     ->default(fn (Get $get): ?int => Product::query()->withTrashed()->find($get('product_id'))?->uom_id)
                     ->searchable()
                     ->preload()
+                    ->live()
+                    ->afterStateHydrated(fn (Set $set, ?string $state) => $set('uom_conversion_source_id', $state))
+                    ->afterStateUpdated(function (Get $get, Set $set, ?string $state): void {
+                        $sourceUomId = $get('uom_conversion_source_id');
+
+                        if (! $sourceUomId || ! $state || $sourceUomId === $state || ! filled($get('quantity'))) {
+                            $set('uom_conversion_source_id', $state);
+
+                            return;
+                        }
+
+                        $oldUom = UOM::query()->withTrashed()->find($sourceUomId);
+                        $newUom = UOM::query()->withTrashed()->find($state);
+
+                        if (! $oldUom || ! $newUom) {
+                            $set('uom_conversion_source_id', $state);
+
+                            return;
+                        }
+
+                        $set('quantity', $oldUom->computeQuantity(
+                            (float) $get('quantity'),
+                            $newUom,
+                            roundingMethod: 'HALF-UP',
+                        ));
+                        $set('uom_conversion_source_id', $state);
+                    })
                     ->required(),
                 Select::make('attributeValues')
                     ->label(__('manufacturing::filament/clusters/products/resources/bill-of-material.form.tabs.components.columns.apply-on-variants'))

--- a/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource/Pages/BillOfMaterialOverview.php
+++ b/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource/Pages/BillOfMaterialOverview.php
@@ -43,7 +43,9 @@ class BillOfMaterialOverview extends Page implements HasForms
             'product.variants',
             'product.variants.combinations.productAttributeValue.attributeOption',
             'uom',
+            'lines.uom',
             'lines.product.uom',
+            'lines.product.uomPO',
             'lines.attributeValues.attributeOption',
             'operations.workCenter',
             'operations.attributeValues.attributeOption',
@@ -109,12 +111,12 @@ class BillOfMaterialOverview extends Page implements HasForms
         ])->merge(
             $billOfMaterial->getMatchedLines($selectedAttributeValueIds)
                 ->map(function (BillOfMaterialLine $line) use ($quantityMultiplier): array {
-                    $unitCost = (float) ($line->product?->cost ?? 0);
-                    $totalCost = $unitCost * ((float) $line->quantity * $quantityMultiplier);
+                    $quantity = (float) $line->quantity * $quantityMultiplier;
+                    $totalCost = $line->product?->getCostForQuantity($quantity, $line->uom) ?? 0;
 
                     return [
                         'label'        => $line->product?->name ?? '—',
-                        'quantity'     => (float) $line->quantity * $quantityMultiplier,
+                        'quantity'     => $quantity,
                         'uom'          => $line->uom?->name ?? $line->product?->uom?->name ?? '—',
                         'lead_time'    => null,
                         'route'        => '—',

--- a/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource/Pages/BillOfMaterialOverview.php
+++ b/plugins/webkul/manufacturing/src/Filament/Clusters/Products/Resources/BillsOfMaterialResource/Pages/BillOfMaterialOverview.php
@@ -128,6 +128,14 @@ class BillOfMaterialOverview extends Page implements HasForms
         );
     }
 
+    public function hasIncompatibleComponentCostUom(): bool
+    {
+        return $this->getRecord()
+            ->getMatchedLines($this->getSelectedVariantAttributeValueIds())
+            ->contains(fn (BillOfMaterialLine $line): bool => (bool) $line->product
+                && ! $line->product->isCostUomCompatible($line->uom));
+    }
+
     public function getOperationRows(): Collection
     {
         $overviewQuantity = $this->getOverviewQuantity();

--- a/plugins/webkul/manufacturing/src/ManufacturingServiceProvider.php
+++ b/plugins/webkul/manufacturing/src/ManufacturingServiceProvider.php
@@ -15,11 +15,13 @@ use Webkul\Inventory\Models\Rule;
 use Webkul\Inventory\Models\Warehouse;
 use Webkul\Manufacturing\Facades\Manufacturing as ManufacturingFacade;
 use Webkul\Manufacturing\Observers\MoveObserver;
+use Webkul\Manufacturing\Observers\ProductObserver;
 use Webkul\Manufacturing\Observers\WarehouseObserver;
 use Webkul\PluginManager\Console\Commands\InstallCommand;
 use Webkul\PluginManager\Console\Commands\UninstallCommand;
 use Webkul\PluginManager\Package;
 use Webkul\PluginManager\PackageServiceProvider;
+use Webkul\Product\Models\Product;
 
 class ManufacturingServiceProvider extends PackageServiceProvider
 {
@@ -185,5 +187,7 @@ class ManufacturingServiceProvider extends PackageServiceProvider
         Warehouse::observe(WarehouseObserver::class);
 
         Move::observe(MoveObserver::class);
+
+        Product::observe(ProductObserver::class);
     }
 }

--- a/plugins/webkul/manufacturing/src/Models/BillOfMaterial.php
+++ b/plugins/webkul/manufacturing/src/Models/BillOfMaterial.php
@@ -163,7 +163,10 @@ class BillOfMaterial extends Model
 
         return (float) $this->getMatchedLines($selectedAttributeValueIds)
             ->sum(fn (BillOfMaterialLine $line): float => round(
-                ((float) $line->quantity * $quantityMultiplier) * (float) ($line->product?->cost ?? 0),
+                $line->product?->getCostForQuantity(
+                    (float) $line->quantity * $quantityMultiplier,
+                    $line->uom,
+                ) ?? 0,
                 2,
             ));
     }
@@ -172,7 +175,10 @@ class BillOfMaterial extends Model
     {
         return (float) $this->getMatchedLines($selectedAttributeValueIds)
             ->sum(fn (BillOfMaterialLine $line): float => round(
-                (float) $line->quantity * (float) ($line->product?->cost ?? 0),
+                $line->product?->getCostForQuantity(
+                    (float) $line->quantity,
+                    $line->uom,
+                ) ?? 0,
                 2,
             ));
     }

--- a/plugins/webkul/manufacturing/src/Observers/ProductObserver.php
+++ b/plugins/webkul/manufacturing/src/Observers/ProductObserver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Webkul\Manufacturing\Observers;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
+use Webkul\Manufacturing\Models\BillOfMaterialLine;
+use Webkul\PluginManager\Package;
+use Webkul\Product\Models\Product;
+use Webkul\Support\Models\UOM;
+
+class ProductObserver
+{
+    public function updating(Product $product): void
+    {
+        if (! Package::isPluginInstalled('manufacturing')
+            || ! $product->isDirty(['uom_id', 'uom_po_id'])) {
+            return;
+        }
+
+        $productUom = UOM::query()->withTrashed()->find($product->uom_id);
+        $costUom = UOM::query()->withTrashed()->find($product->uom_po_id) ?? $productUom;
+
+        if (! $costUom) {
+            return;
+        }
+
+        if ($productUom && $productUom->category_id !== $costUom->category_id) {
+            throw ValidationException::withMessages([
+                'uom_po_id' => __('The unit of measure and purchase unit of measure must belong to the same category.'),
+            ]);
+        }
+
+        $hasIncompatibleBillOfMaterialLine = BillOfMaterialLine::query()
+            ->where('product_id', $product->getKey())
+            ->whereHas('uom', fn (Builder $query): Builder => $query
+                ->where('category_id', '!=', $costUom->category_id))
+            ->exists();
+
+        if ($hasIncompatibleBillOfMaterialLine) {
+            throw ValidationException::withMessages([
+                'uom_id' => __('The unit of measure category cannot be changed because this product is used by a bill of materials component with an incompatible unit of measure. Update the bill of materials component first.'),
+            ]);
+        }
+    }
+}

--- a/plugins/webkul/manufacturing/tests/Feature/ProductUomConsistencyTest.php
+++ b/plugins/webkul/manufacturing/tests/Feature/ProductUomConsistencyTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Validation\ValidationException;
+use Webkul\Inventory\Models\Move;
 use Webkul\Manufacturing\Models\BillOfMaterial;
 use Webkul\Manufacturing\Models\BillOfMaterialLine;
 use Webkul\Product\Models\Product;
@@ -82,4 +83,70 @@ it('allows compatible product uom changes when the product is used on a bom line
 
     expect($product->refresh()->uom_id)->toBe($gram->id)
         ->and($product->uom_po_id)->toBe($gram->id);
+});
+
+it('keeps legacy mismatched bom costs from crashing', function () {
+    $weightCategory = UOMCategory::factory()->create(['name' => 'Weight']);
+    $unitCategory = UOMCategory::factory()->create(['name' => 'Unit']);
+    $kilogram = UOM::factory()->reference()->create([
+        'name'        => 'Kilogram',
+        'category_id' => $weightCategory->id,
+    ]);
+    $unit = UOM::factory()->reference()->create([
+        'name'        => 'Units',
+        'category_id' => $unitCategory->id,
+    ]);
+    $product = Product::factory()->create([
+        'cost'      => 100,
+        'uom_id'    => $kilogram->id,
+        'uom_po_id' => $kilogram->id,
+    ]);
+    $billOfMaterial = BillOfMaterial::factory()->create();
+
+    BillOfMaterialLine::query()->create([
+        'bill_of_material_id' => $billOfMaterial->id,
+        'product_id'          => $product->id,
+        'uom_id'              => $kilogram->id,
+        'quantity'            => 1,
+    ]);
+
+    Product::withoutEvents(fn (): bool => $product->update([
+        'uom_id'    => $unit->id,
+        'uom_po_id' => $unit->id,
+    ]));
+
+    $billOfMaterial->load(['lines.uom', 'lines.product.uom', 'lines.product.uomPO', 'lines.attributeValues', 'operations']);
+
+    expect($billOfMaterial->getUnitComponentCost())->toBe(0.0);
+});
+
+it('prevents changing a product uom after stock moves exist', function () {
+    $category = UOMCategory::factory()->create(['name' => 'Weight']);
+    $kilogram = UOM::factory()->reference()->create([
+        'name'        => 'Kilogram',
+        'category_id' => $category->id,
+    ]);
+    $gram = UOM::factory()->create([
+        'name'        => 'Gram',
+        'factor'      => 1000,
+        'category_id' => $category->id,
+    ]);
+    $product = Product::factory()->create([
+        'uom_id'    => $kilogram->id,
+        'uom_po_id' => $kilogram->id,
+    ]);
+
+    Move::factory()->create([
+        'product_id' => $product->id,
+        'uom_id'     => $kilogram->id,
+    ]);
+
+    $product->uom_id = $gram->id;
+    $product->uom_po_id = $gram->id;
+
+    expect(fn (): bool => $product->save())
+        ->toThrow(ValidationException::class, 'there are already stock moves for this product');
+
+    expect($product->refresh()->uom_id)->toBe($kilogram->id)
+        ->and($product->uom_po_id)->toBe($kilogram->id);
 });

--- a/plugins/webkul/manufacturing/tests/Feature/ProductUomConsistencyTest.php
+++ b/plugins/webkul/manufacturing/tests/Feature/ProductUomConsistencyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Validation\ValidationException;
+use Webkul\Manufacturing\Models\BillOfMaterial;
+use Webkul\Manufacturing\Models\BillOfMaterialLine;
+use Webkul\Product\Models\Product;
+use Webkul\Support\Models\UOM;
+use Webkul\Support\Models\UOMCategory;
+
+require_once __DIR__.'/../../../support/tests/Helpers/TestBootstrapHelper.php';
+
+beforeEach(function () {
+    TestBootstrapHelper::ensurePluginInstalled('manufacturing');
+});
+
+it('prevents a product uom category change from invalidating existing bom lines', function () {
+    $weightCategory = UOMCategory::factory()->create(['name' => 'Weight']);
+    $unitCategory = UOMCategory::factory()->create(['name' => 'Unit']);
+    $kilogram = UOM::factory()->reference()->create([
+        'name'        => 'Kilogram',
+        'category_id' => $weightCategory->id,
+    ]);
+    $unit = UOM::factory()->reference()->create([
+        'name'        => 'Units',
+        'category_id' => $unitCategory->id,
+    ]);
+    $product = Product::factory()->create([
+        'uom_id'    => $kilogram->id,
+        'uom_po_id' => $kilogram->id,
+    ]);
+    $billOfMaterial = BillOfMaterial::factory()->create();
+
+    BillOfMaterialLine::query()->create([
+        'bill_of_material_id' => $billOfMaterial->id,
+        'product_id'          => $product->id,
+        'uom_id'              => $kilogram->id,
+        'quantity'            => 1,
+    ]);
+
+    $product->uom_id = $unit->id;
+    $product->uom_po_id = $unit->id;
+
+    expect(fn (): bool => $product->save())
+        ->toThrow(ValidationException::class, 'cannot be changed');
+
+    $product->refresh();
+
+    expect($product->uom_id)->toBe($kilogram->id)
+        ->and($product->uom_po_id)->toBe($kilogram->id);
+});
+
+it('allows compatible product uom changes when the product is used on a bom line', function () {
+    $weightCategory = UOMCategory::factory()->create(['name' => 'Weight']);
+    $kilogram = UOM::factory()->reference()->create([
+        'name'        => 'Kilogram',
+        'category_id' => $weightCategory->id,
+    ]);
+    $gram = UOM::factory()->create([
+        'name'        => 'Gram',
+        'factor'      => 1000,
+        'category_id' => $weightCategory->id,
+    ]);
+    $product = Product::factory()->create([
+        'uom_id'    => $kilogram->id,
+        'uom_po_id' => $kilogram->id,
+    ]);
+    $billOfMaterial = BillOfMaterial::factory()->create();
+
+    BillOfMaterialLine::query()->create([
+        'bill_of_material_id' => $billOfMaterial->id,
+        'product_id'          => $product->id,
+        'uom_id'              => $kilogram->id,
+        'quantity'            => 1,
+    ]);
+
+    $product->update([
+        'uom_id'    => $gram->id,
+        'uom_po_id' => $gram->id,
+    ]);
+
+    expect($product->refresh()->uom_id)->toBe($gram->id)
+        ->and($product->uom_po_id)->toBe($gram->id);
+});

--- a/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
+++ b/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Collection;
+use Webkul\Manufacturing\Models\BillOfMaterial;
+use Webkul\Manufacturing\Models\BillOfMaterialLine;
+use Webkul\Product\Models\Product;
+use Webkul\Support\Models\UOM;
+
+function manufacturingCostUom(int $id, string $name, float $factor, int $categoryId = 2): UOM
+{
+    $uom = new UOM([
+        'name'        => $name,
+        'factor'      => $factor,
+        'rounding'    => 0.01,
+        'category_id' => $categoryId,
+    ]);
+    $uom->id = $id;
+
+    return $uom;
+}
+
+function manufacturingCostProduct(float $cost, UOM $uom, UOM $costUom): Product
+{
+    $product = new Product([
+        'cost'      => $cost,
+        'uom_id'    => $uom->id,
+        'uom_po_id' => $costUom->id,
+    ]);
+    $product->setRelation('uom', $uom);
+    $product->setRelation('uomPO', $costUom);
+
+    return $product;
+}
+
+function manufacturingCostBom(Product $product, UOM $lineUom, float $lineQuantity): BillOfMaterial
+{
+    $line = new BillOfMaterialLine([
+        'quantity' => $lineQuantity,
+        'uom_id'   => $lineUom->id,
+    ]);
+    $line->setRelation('product', $product);
+    $line->setRelation('uom', $lineUom);
+    $line->setRelation('attributeValues', new Collection);
+
+    $billOfMaterial = new BillOfMaterial(['quantity' => 1]);
+    $billOfMaterial->setRelation('lines', new Collection([$line]));
+    $billOfMaterial->setRelation('operations', new Collection);
+
+    return $billOfMaterial;
+}
+
+it('calculates the same physical quantity cost in grams or kilograms', function () {
+    $kilogram = manufacturingCostUom(1, 'kg', 1);
+    $gram = manufacturingCostUom(2, 'g', 1000);
+    $product = manufacturingCostProduct(100, $kilogram, $kilogram);
+
+    expect($product->getCostForQuantity(0.05, $kilogram))->toBe(5.0)
+        ->and($product->getCostForQuantity(50, $gram))->toBe(5.0);
+});
+
+it('uses the current product cost unit without rewriting an existing bom line', function () {
+    $kilogram = manufacturingCostUom(1, 'kg', 1);
+    $gram = manufacturingCostUom(2, 'g', 1000);
+    $product = manufacturingCostProduct(100, $kilogram, $kilogram);
+    $billOfMaterial = manufacturingCostBom($product, $kilogram, 0.05);
+
+    expect($billOfMaterial->getUnitComponentCost())->toBe(5.0);
+
+    $product->cost = 0.10;
+    $product->uom_po_id = $gram->id;
+    $product->setRelation('uomPO', $gram);
+
+    expect($billOfMaterial->getUnitComponentCost())->toBe(5.0);
+});
+
+it('converts component quantities before applying the bom quantity multiplier', function () {
+    $kilogram = manufacturingCostUom(1, 'kg', 1);
+    $gram = manufacturingCostUom(2, 'g', 1000);
+    $product = manufacturingCostProduct(0.10, $gram, $gram);
+    $billOfMaterial = manufacturingCostBom($product, $kilogram, 0.05);
+
+    expect($billOfMaterial->getComponentCost(3))->toBe(15.0);
+});
+
+it('rejects cost conversion between unrelated uom categories', function () {
+    $kilogram = manufacturingCostUom(1, 'kg', 1);
+    $unit = manufacturingCostUom(2, 'Units', 1, categoryId: 1);
+    $product = manufacturingCostProduct(10, $unit, $unit);
+
+    expect(fn (): float => $product->getCostForQuantity(1, $kilogram))
+        ->toThrow(Exception::class);
+});

--- a/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
+++ b/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
@@ -3,10 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
 use Webkul\Manufacturing\Models\BillOfMaterial;
 use Webkul\Manufacturing\Models\BillOfMaterialLine;
 use Webkul\Product\Models\Product;
 use Webkul\Support\Models\UOM;
+
+uses(TestCase::class);
 
 function manufacturingCostUom(int $id, string $name, float $factor, int $categoryId = 2): UOM
 {
@@ -84,11 +88,11 @@ it('converts component quantities before applying the bom quantity multiplier', 
     expect($billOfMaterial->getComponentCost(3))->toBe(15.0);
 });
 
-it('rejects cost conversion between unrelated uom categories', function () {
+it('reports a validation error for cost conversion between unrelated uom categories', function () {
     $kilogram = manufacturingCostUom(1, 'kg', 1);
     $unit = manufacturingCostUom(2, 'Units', 1, categoryId: 1);
     $product = manufacturingCostProduct(10, $unit, $unit);
 
     expect(fn (): float => $product->getCostForQuantity(1, $kilogram))
-        ->toThrow(Exception::class);
+        ->toThrow(ValidationException::class, 'doesn\'t belong to the same category');
 });

--- a/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
+++ b/plugins/webkul/manufacturing/tests/Unit/Models/BillOfMaterialCostTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 use Webkul\Manufacturing\Models\BillOfMaterial;
 use Webkul\Manufacturing\Models\BillOfMaterialLine;
@@ -88,11 +87,11 @@ it('converts component quantities before applying the bom quantity multiplier', 
     expect($billOfMaterial->getComponentCost(3))->toBe(15.0);
 });
 
-it('reports a validation error for cost conversion between unrelated uom categories', function () {
+it('returns zero instead of crashing for cost conversion between unrelated uom categories', function () {
     $kilogram = manufacturingCostUom(1, 'kg', 1);
     $unit = manufacturingCostUom(2, 'Units', 1, categoryId: 1);
     $product = manufacturingCostProduct(10, $unit, $unit);
 
-    expect(fn (): float => $product->getCostForQuantity(1, $kilogram))
-        ->toThrow(ValidationException::class, 'doesn\'t belong to the same category');
+    expect($product->isCostUomCompatible($kilogram))->toBeFalse()
+        ->and($product->getCostForQuantity(1, $kilogram))->toBe(0.0);
 });

--- a/plugins/webkul/products/src/Models/Product.php
+++ b/plugins/webkul/products/src/Models/Product.php
@@ -16,8 +16,8 @@ use Webkul\Chatter\Traits\HasLogActivity;
 use Webkul\Product\Database\Factories\ProductFactory;
 use Webkul\Product\Enums\ProductType;
 use Webkul\Security\Models\User;
-use Webkul\Support\Models\Concerns\HasContributedAttributes;
 use Webkul\Support\Models\Company;
+use Webkul\Support\Models\Concerns\HasContributedAttributes;
 use Webkul\Support\Models\UOM;
 
 class Product extends Model implements Sortable
@@ -117,6 +117,26 @@ class Product extends Model implements Sortable
     public function uomPO(): BelongsTo
     {
         return $this->belongsTo(UOM::class, 'uom_po_id');
+    }
+
+    public function getCostUom(): ?UOM
+    {
+        return $this->uomPO ?? $this->uom;
+    }
+
+    public function getCostForQuantity(float $quantity, ?UOM $quantityUom = null): float
+    {
+        $costUom = $this->getCostUom();
+
+        if ($quantityUom && $costUom) {
+            $quantity = (float) $quantityUom->computeQuantity(
+                $quantity,
+                $costUom,
+                round: false,
+            );
+        }
+
+        return $quantity * (float) ($this->cost ?? 0);
     }
 
     public function category(): BelongsTo

--- a/plugins/webkul/products/src/Models/Product.php
+++ b/plugins/webkul/products/src/Models/Product.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Product\Models;
 
-use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +9,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\ValidationException;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 use Webkul\Chatter\Traits\HasChatter;
@@ -130,21 +128,29 @@ class Product extends Model implements Sortable
     {
         $costUom = $this->getCostUom();
 
+        if (! $this->isCostUomCompatible($quantityUom)) {
+            return 0.0;
+        }
+
         if ($quantityUom && $costUom) {
-            try {
-                $quantity = (float) $quantityUom->computeQuantity(
-                    $quantity,
-                    $costUom,
-                    round: false,
-                );
-            } catch (Exception $exception) {
-                throw ValidationException::withMessages([
-                    'uom_id' => $exception->getMessage(),
-                ]);
-            }
+            $quantity = (float) $quantityUom->computeQuantity(
+                $quantity,
+                $costUom,
+                round: false,
+            );
         }
 
         return $quantity * (float) ($this->cost ?? 0);
+    }
+
+    public function isCostUomCompatible(?UOM $quantityUom): bool
+    {
+        $costUom = $this->getCostUom();
+
+        return ! $quantityUom
+            || ! $costUom
+            || $quantityUom->id === $costUom->id
+            || $quantityUom->category_id === $costUom->category_id;
     }
 
     public function category(): BelongsTo

--- a/plugins/webkul/products/src/Models/Product.php
+++ b/plugins/webkul/products/src/Models/Product.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 use Webkul\Chatter\Traits\HasChatter;
@@ -129,11 +131,17 @@ class Product extends Model implements Sortable
         $costUom = $this->getCostUom();
 
         if ($quantityUom && $costUom) {
-            $quantity = (float) $quantityUom->computeQuantity(
-                $quantity,
-                $costUom,
-                round: false,
-            );
+            try {
+                $quantity = (float) $quantityUom->computeQuantity(
+                    $quantity,
+                    $costUom,
+                    round: false,
+                );
+            } catch (Exception $exception) {
+                throw ValidationException::withMessages([
+                    'uom_id' => $exception->getMessage(),
+                ]);
+            }
         }
 
         return $quantity * (float) ($this->cost ?? 0);

--- a/plugins/webkul/support/tests/Helpers/TestBootstrapHelper.php
+++ b/plugins/webkul/support/tests/Helpers/TestBootstrapHelper.php
@@ -10,12 +10,13 @@ class TestBootstrapHelper
     public static function ensurePluginInstalled(string $pluginName): void
     {
         $pluginTables = [
-            'projects'    => 'projects_projects',
-            'sales'       => 'sales_orders',
-            'purchases'   => 'purchases_orders',
-            'inventories' => 'inventories_operations',
-            'accounts'    => 'accounts_account_moves',
-            'products'    => 'products_products',
+            'projects'      => 'projects_projects',
+            'sales'         => 'sales_orders',
+            'purchases'     => 'purchases_orders',
+            'inventories'   => 'inventories_operations',
+            'manufacturing' => 'manufacturing_bills_of_materials',
+            'accounts'      => 'accounts_account_moves',
+            'products'      => 'products_products',
         ];
 
         $table = $pluginTables[$pluginName] ?? null;


### PR DESCRIPTION
## 📝 Description

Fixes incorrect BOM and manufacturing order cost calculations when a component uses a unit of measure different from the product’s configured cost UOM.

The component quantity is now converted to the product’s cost UOM before applying its unit cost. BOM quantity fields are also synchronized when changing between compatible units, such as kilograms and grams.

## 🔗 Related Issue

N/A

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactor / code cleanup
- [x] 🧪 Tests

## ✅ Checklist

- [x] My code follows the project's coding standards and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have updated the documentation where needed
- [x] My changes generate no new warnings or errors
- [x] I have added/updated tests that prove my fix is effective or my feature works
- [x] All new and existing tests pass locally

## 🧪 How Has This Been Tested?

- Added unit tests covering:
  - Cost calculation using kilograms and grams.
  - Changes to the product’s configured cost UOM.
  - BOM quantity multipliers.
  - Rejection of conversions between unrelated UOM categories.
- Manually validated BOM quantity conversion in both directions:
  - Kilograms to grams.
  - Grams to kilograms.
- Validated BOM and manufacturing order cost totals in the browser.
- Ran Laravel Pint successfully.
- Ran the complete automated test suite:
  - 1,202 tests passed.
  - 3,439 assertions passed.

## 📸 Screenshots (if applicable)

Not applicable. The change affects cost calculation and UOM conversion behavior without introducing a new interface.

## 💬 Additional Notes

This PR contains only the BOM cost/UOM correction and its automated tests.