### PR TITLE
Fix: Prevent users from viewing or changing chatter messages on records they don't have access to

### DIFF
--- a/plugins/webkul/chatter/src/Livewire/ChatterPanel.php
+++ b/plugins/webkul/chatter/src/Livewire/ChatterPanel.php
@@ -42,7 +42,6 @@ use Webkul\Chatter\Filament\Infolists\Components\Activities\TitleTextEntry as Ac
 use Webkul\Chatter\Filament\Infolists\Components\Messages\ContentTextEntry as MessageContentTextEntry;
 use Webkul\Chatter\Filament\Infolists\Components\Messages\MessageRepeatableEntry;
 use Webkul\Chatter\Filament\Infolists\Components\Messages\TitleTextEntry as MessageTitleTextEntry;
-use Webkul\Chatter\Models\Message;
 use Webkul\Partner\Models\Partner;
 use Webkul\Security\Models\User;
 use Webkul\Support\Models\ActivityPlan;
@@ -500,7 +499,7 @@ class ChatterPanel extends Component implements HasActions, HasForms, HasInfolis
 
     protected function processMessage(int $messageId, ?string $feedback): void
     {
-        $message = Message::find($messageId);
+        $message = $this->record->activities()->find($messageId);
 
         if (! $message) {
             return;
@@ -528,7 +527,11 @@ class ChatterPanel extends Component implements HasActions, HasForms, HasInfolis
             ->label(__('chatter::livewire/chatter-panel.edit-activity.title'))
             ->mountUsing(function (Schema $schema, $arguments) {
                 $activityId = $arguments['id'] ?? null;
-                $record = Message::find($activityId);
+                $record = $this->record->activities()->find($activityId);
+
+                if (! $record) {
+                    return;
+                }
 
                 $schema->fill([
                     'activity_plan_id' => $record->activity_plan_id,
@@ -625,7 +628,11 @@ class ChatterPanel extends Component implements HasActions, HasForms, HasInfolis
             ->action(function (array $data, $arguments) {
                 $activityId = $arguments['id'] ?? null;
 
-                $record = Message::find($activityId);
+                $record = $this->record->activities()->find($activityId);
+
+                if (! $record) {
+                    return;
+                }
 
                 $record->update($data);
 
@@ -683,7 +690,7 @@ class ChatterPanel extends Component implements HasActions, HasForms, HasInfolis
 
     public function pinMessage(int $id): void
     {
-        $message = Message::find($id);
+        $message = $this->record->messages()->find($id);
 
         if (! $message) {
             return;


### PR DESCRIPTION
The problem

  The Chatter panel (the comments/activity feed attached to records across Sales, Purchase, Accounting, Inventory, Projects, and more) had a gap in its access checks. A logged-in user could act on messages that don't belong to the record they're viewing, including records in other departments or even other companies in a multi-company setup just by referencing a message's ID.

  In practice, this meant a user could:
  - See private content, they shouldn't see the full text, summary, deadline, and assignee of any activity note anywhere in the system.
  - Change or delete messages they shouldn't pin/unpin, edit, or remove messages on records they have no access to. Pinning also silently overwrote the "last changed by" audit information, making it look like someone else made the change.

  Because message IDs are simple sequential numbers, someone could step through them one by one to read notes in bulk.

  The solution

  Every message action in the Chatter panel now confirms that the message actually belongs to the record currently open before doing anything. If it doesn't belong, the action quietly does nothing; no data is shown, changed, or deleted.

  This closes the gap for viewing, pinning, editing, and deleting messages, so users can only interact with the messages on records they're genuinely allowed to access.
  There is no change to the normal, legitimate use of the Chatter panel.