### PR TITLE
Fix: Prevent SQL error during seeding by filtering partner attributes…

### DIFF
--- a/plugins/webkul/security/src/Models/User.php
+++ b/plugins/webkul/security/src/Models/User.php
@@ -144,12 +144,14 @@ class User extends BaseUser implements FilamentUser, HasAppAuthentication, HasAp
 
     private function handlePartnerCreation(self $user)
     {
+        $partnerAttributes = Arr::only($user->toArray(), app(Partner::class)->getFillable());
+
         $partner = $user->partner()->create([
+            ...$partnerAttributes,
             'creator_id' => Auth::user()->id ?? $user->id,
             'company_id' => $user->default_company_id,
             'user_id'    => $user->id,
             'sub_type'   => 'partner',
-            ...Arr::except($user->toArray(), ['id', 'partner_id', 'email_verified_at']),
         ]);
 
         $user->partner_id = $partner->id;
@@ -158,14 +160,16 @@ class User extends BaseUser implements FilamentUser, HasAppAuthentication, HasAp
 
     private function handlePartnerUpdation(self $user)
     {
+        $partnerAttributes = Arr::only($user->toArray(), app(Partner::class)->getFillable());
+
         $partner = Partner::withoutGlobalScopes()->updateOrCreate(
             ['id' => $user->partner_id],
             [
+                ...$partnerAttributes,
                 'creator_id' => Auth::user()->id ?? $user->id,
                 'company_id' => $user->default_company_id,
                 'user_id'    => $user->id,
                 'sub_type'   => 'partner',
-                ...Arr::except($user->toArray(), ['id', 'partner_id', 'email_verified_at']),
             ]
         );
 


### PR DESCRIPTION
## 📝 Description

This PR fixes a critical SQL exception that occurs when running database seeders. 

During seeding, Laravel automatically disables mass assignment protection (`Model::unguard()`). The `Webkul\Security\Models\User` model creates a `Partner` record and passes attributes using a blacklist approach: `Arr::except($user->toArray(), ['id', 'partner_id', 'email_verified_at'])`. As a result, when unguarded, columns that do not exist in the `partners_partners` table (such as `is_default`) are passed, causing the seeder to crash.

This PR replaces `Arr::except` with a robust whitelist approach using `Arr::only`, filtering the attributes based on the `Partner` model's `$fillable` array. This ensures only valid database columns are ever passed.

## 🔗 Related Issue

Closes [#1484 ]

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] ♻️ Refactor / code cleanup
- [ ] 🧪 Tests

## ✅ Checklist

- [x] My code follows the project's coding standards and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation where needed
- [x] My changes generate no new warnings or errors
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [x] All new and existing tests pass locally

## 🧪 How Has This Been Tested?

1. Ran database seeders (`php artisan db:seed`) that generate users using the Webkul `User` model.
2. Verified that the seeder executes successfully and creates the user and partner records without throwing the `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'is_default'` exception.

## 📸 Screenshots (if applicable)

N/A

## 💬 Additional Notes

Using `Arr::only` mapped to `getFillable()` makes the codebase much safer and prevents unexpected crashes if more attributes are added to the User model in the future.