### PR TITLE
fix: Add show/hide option for new password fields in EditUser form

### DIFF
--- a/plugins/webkul/security/src/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/plugins/webkul/security/src/Filament/Resources/UserResource/Pages/EditUser.php
@@ -49,11 +49,13 @@ class EditUser extends EditRecord
                 ->schema([
                     TextInput::make('new_password')
                         ->password()
+                        ->revealable()
                         ->label(__('security::filament/resources/user/pages/edit-user.header-actions.change-password.form.new-password'))
                         ->required()
                         ->rule(Password::default()),
                     TextInput::make('new_password_confirmation')
                         ->password()
+                        ->revealable()
                         ->label(__('security::filament/resources/user/pages/edit-user.header-actions.change-password.form.confirm-new-password'))
                         ->rule('required', fn ($get) => (bool) $get('new_password'))
                         ->same('new_password'),


### PR DESCRIPTION
Added

<img width="1282" height="501" alt="image" src="https://github.com/user-attachments/assets/791fee16-ba05-4c40-bc8e-141dc3a16938" />
