### PR TITLE
Issue #1491 has been fixed

### DIFF
--- a/plugins/webkul/employees/src/Models/Employee.php
+++ b/plugins/webkul/employees/src/Models/Employee.php
@@ -268,7 +268,6 @@ class Employee extends Model
             'phone'        => $employee?->work_phone,
             'mobile'       => $employee?->mobile_phone,
             'color'        => $employee?->color,
-            'parent_id'    => $employee?->parent_id,
             'company_id'   => $employee?->company_id,
             'user_id'      => $employee?->user_id,
         ]);
@@ -291,7 +290,6 @@ class Employee extends Model
                 'phone'        => $employee?->work_phone,
                 'mobile'       => $employee?->mobile_phone,
                 'color'        => $employee?->color,
-                'parent_id'    => $employee?->parent_id,
                 'company_id'   => $employee?->company_id,
                 'user_id'      => $employee?->user_id,
             ]


### PR DESCRIPTION
Employee.parent_id is the Manager (FK → employees_employees.id), but handlePartnerCreation() / handlePartnerUpdation() copied that raw id straight into
  partners_partners.parent_id, which is a FK to partners_partners.id and means Company, not manager. Different id spaces, so saving an employee with a manager
  blew up with SQLSTATE[23000] ... partners_partners_parent_id_foreign — and when the id happened to exist, it silently overwrote the partner's real Company.

  Fix: drop parent_id from both partner sync payloads. Manager stays on the employee record; nothing reads partner->parent as a manager.

  Fixes #1491