### PR TITLE
issue #1489 fixed

### DIFF
--- a/plugins/webkul/accounts/src/Filament/Resources/CustomerResource/Pages/ListCustomers.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/CustomerResource/Pages/ListCustomers.php
@@ -18,4 +18,13 @@ class ListCustomers extends ListPartners
                 ->icon('heroicon-o-plus-circle'),
         ];
     }
+
+    public function getPresetTableViews(): array
+    {
+        $views = parent::getPresetTableViews();
+
+        unset($views['employees'], $views['customers'], $views['vendors']);
+
+        return $views;
+    }
 }

--- a/plugins/webkul/accounts/src/Filament/Resources/VendorResource/Pages/ListVendors.php
+++ b/plugins/webkul/accounts/src/Filament/Resources/VendorResource/Pages/ListVendors.php
@@ -18,4 +18,13 @@ class ListVendors extends ListPartners
                 ->icon('heroicon-o-plus-circle'),
         ];
     }
+
+    public function getPresetTableViews(): array
+    {
+        $views = parent::getPresetTableViews();
+
+        unset($views['employees'], $views['customers'], $views['vendors']);
+
+        return $views;
+    }
 }

--- a/plugins/webkul/partners/resources/lang/ar/filament/resources/partner/pages/list-partners.php
+++ b/plugins/webkul/partners/resources/lang/ar/filament/resources/partner/pages/list-partners.php
@@ -13,6 +13,8 @@ return [
         'individuals' => 'أفراد',
         'companies'   => 'شركات',
         'employees'   => 'موظفون',
+        'customers'   => 'عملاء',
+        'vendors'     => 'موردون',
         'archived'    => 'مؤرشف',
     ],
 ];

--- a/plugins/webkul/partners/resources/lang/en/filament/resources/partner/pages/list-partners.php
+++ b/plugins/webkul/partners/resources/lang/en/filament/resources/partner/pages/list-partners.php
@@ -13,6 +13,8 @@ return [
         'individuals' => 'Individuals',
         'companies'   => 'Companies',
         'employees'   => 'Employees',
+        'customers'   => 'Customers',
+        'vendors'     => 'Vendors',
         'archived'    => 'Archived',
     ],
 ];

--- a/plugins/webkul/partners/resources/lang/es/filament/resources/partner/pages/list-partners.php
+++ b/plugins/webkul/partners/resources/lang/es/filament/resources/partner/pages/list-partners.php
@@ -13,6 +13,8 @@ return [
         'individuals' => 'Particulares',
         'companies'   => 'Empresas',
         'employees'   => 'Empleados',
+        'customers'   => 'Clientes',
+        'vendors'     => 'Proveedores',
         'archived'    => 'Archivados',
     ],
 ];

--- a/plugins/webkul/partners/resources/lang/fr/filament/resources/partner/pages/list-partners.php
+++ b/plugins/webkul/partners/resources/lang/fr/filament/resources/partner/pages/list-partners.php
@@ -13,6 +13,8 @@ return [
         'individuals' => 'Particuliers',
         'companies'   => 'Sociétés',
         'employees'   => 'Employés',
+        'customers'   => 'Clients',
+        'vendors'     => 'Fournisseurs',
         'archived'    => 'Archivés',
     ],
 ];

--- a/plugins/webkul/partners/resources/lang/pt_BR/filament/resources/partner/pages/list-partners.php
+++ b/plugins/webkul/partners/resources/lang/pt_BR/filament/resources/partner/pages/list-partners.php
@@ -13,6 +13,8 @@ return [
         'individuals' => 'Pessoas físicas',
         'companies'   => 'Empresas',
         'employees'   => 'Colaboradores',
+        'customers'   => 'Clientes',
+        'vendors'     => 'Fornecedores',
         'archived'    => 'Arquivados',
     ],
 ];

--- a/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ListPartners.php
+++ b/plugins/webkul/partners/src/Filament/Resources/PartnerResource/Pages/ListPartners.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Webkul\Partner\Enums\AccountType;
 use Webkul\Partner\Filament\Resources\PartnerResource;
+use Webkul\PluginManager\Package;
 use Webkul\TableViews\Filament\Components\PresetView;
 use Webkul\TableViews\Filament\Concerns\HasTableViews;
 
@@ -33,7 +34,7 @@ class ListPartners extends ListRecords
 
     public function getPresetTableViews(): array
     {
-        return [
+        $views = [
             'individuals' => PresetView::make(__('partners::filament/resources/partner/pages/list-partners.tabs.individuals'))
                 ->icon('heroicon-s-user')
                 ->favorite()
@@ -44,10 +45,32 @@ class ListPartners extends ListRecords
                 ->favorite()
                 ->modifyQueryUsing(fn (Builder $query) => $query->where('account_type', AccountType::COMPANY)),
 
+            'employees' => PresetView::make(__('partners::filament/resources/partner/pages/list-partners.tabs.employees'))
+                ->icon('heroicon-s-identification')
+                ->favorite()
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('sub_type', 'employee')),
+
+            'customers' => PresetView::make(__('partners::filament/resources/partner/pages/list-partners.tabs.customers'))
+                ->icon('heroicon-s-shopping-bag')
+                ->favorite()
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('customer_rank', '>', 0)),
+
+            'vendors' => PresetView::make(__('partners::filament/resources/partner/pages/list-partners.tabs.vendors'))
+                ->icon('heroicon-s-truck')
+                ->favorite()
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('supplier_rank', '>', 0)),
+
             'archived' => PresetView::make(__('partners::filament/resources/partner/pages/list-partners.tabs.archived'))
                 ->icon('heroicon-s-archive-box')
                 ->favorite()
                 ->modifyQueryUsing(fn (Builder $query) => $query->onlyTrashed()),
         ];
+
+        // Customer and vendor ranks are columns the accounts plugin adds.
+        if (! Package::isPluginInstalled('accounts')) {
+            unset($views['customers'], $views['vendors']);
+        }
+
+        return $views;
     }
 }

--- a/plugins/webkul/partners/tests/Feature/Filament/PartnerTypeViewsTest.php
+++ b/plugins/webkul/partners/tests/Feature/Filament/PartnerTypeViewsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Webkul\Account\Filament\Resources\CustomerResource\Pages\ListCustomers;
+use Webkul\Account\Filament\Resources\VendorResource\Pages\ListVendors;
+use Webkul\Partner\Enums\AccountType;
+use Webkul\Partner\Filament\Resources\PartnerResource\Pages\ListPartners;
+use Webkul\Partner\Models\Partner;
+
+require_once __DIR__.'/../../../../support/tests/Helpers/TestBootstrapHelper.php';
+
+beforeEach(function () {
+    // Customer and vendor ranks are columns the accounts plugin adds.
+    TestBootstrapHelper::ensurePluginInstalled('accounts');
+});
+
+/**
+ * Every partner built here is stamped, so the assertions can ignore the partners the
+ * installation seeds for itself.
+ */
+const PARTNER_TYPE_TEST_REFERENCE = 'partner-type-views-test';
+
+function partnerOfType(string $name, array $attributes = []): Partner
+{
+    return Partner::create(array_merge([
+        'account_type' => AccountType::INDIVIDUAL,
+        'sub_type'     => 'partner',
+        'name'         => $name,
+        'reference'    => PARTNER_TYPE_TEST_REFERENCE,
+    ], $attributes));
+}
+
+/**
+ * The names a preset view keeps, out of the partners this test created.
+ */
+function namesInView(string $view): array
+{
+    $query = Partner::query()->where('reference', PARTNER_TYPE_TEST_REFERENCE);
+
+    return (new ListPartners)->getPresetTableViews()[$view]
+        ->modifyQuery($query)
+        ->pluck('name')
+        ->sort()
+        ->values()
+        ->all();
+}
+
+it('keeps only employees in the employees view', function () {
+    partnerOfType('Employee One', ['sub_type' => 'employee']);
+    partnerOfType('Plain Partner');
+    partnerOfType('Ranked Customer', ['customer_rank' => 1]);
+
+    expect(namesInView('employees'))->toBe(['Employee One']);
+});
+
+it('keeps only ranked customers in the customers view', function () {
+    partnerOfType('Ranked Customer', ['customer_rank' => 1]);
+    partnerOfType('Ranked Vendor', ['supplier_rank' => 1]);
+    partnerOfType('Unranked', ['customer_rank' => 0]);
+    partnerOfType('Never Ranked');
+
+    expect(namesInView('customers'))->toBe(['Ranked Customer']);
+});
+
+it('keeps only ranked vendors in the vendors view', function () {
+    partnerOfType('Ranked Vendor', ['supplier_rank' => 1]);
+    partnerOfType('Ranked Customer', ['customer_rank' => 1]);
+    partnerOfType('Unranked', ['supplier_rank' => 0]);
+    partnerOfType('Never Ranked');
+
+    expect(namesInView('vendors'))->toBe(['Ranked Vendor']);
+});
+
+it('leaves the existing views in place', function () {
+    partnerOfType('An Individual');
+    partnerOfType('Acme Corp', ['account_type' => AccountType::COMPANY]);
+
+    expect(namesInView('individuals'))->toBe(['An Individual'])
+        ->and(namesInView('companies'))->toBe(['Acme Corp'])
+        ->and(namesInView('archived'))->toBe([]);
+});
+
+it('offers the type views on the shared contact list in a stable order', function () {
+    expect(array_keys((new ListPartners)->getPresetTableViews()))
+        ->toBe(['individuals', 'companies', 'employees', 'customers', 'vendors', 'archived']);
+});
+
+it('drops the redundant type views on the vendor and customer lists', function (string $page) {
+    $views = array_keys((new $page)->getPresetTableViews());
+
+    expect($views)->not->toContain('employees')
+        ->and($views)->not->toContain('customers')
+        ->and($views)->not->toContain('vendors')
+        ->and($views)->toBe(['individuals', 'companies', 'archived']);
+})->with([[ListVendors::class], [ListCustomers::class]]);


### PR DESCRIPTION
Partner lists only offered Individuals / Companies / Archived views, so internal employees sat mixed in with every other partner and there was no
  straightforward way to look at one type.

  Adds three preset views to ListPartners::getPresetTableViews() — Employees (sub_type = 'employee'), Customers (customer_rank > 0), Vendors (supplier_rank > 
  0). The default view is unchanged, still all partners; these are an optional refinement.

  The views live on the base ListPartners, so Contacts, Website, Accounts, Invoices, Accounting, Purchase and Sales partner lists all inherit them. Vendor and
  Customer screens are already scoped to a single type, so the three views are dropped there — in the accounts ListVendors / ListCustomers, which every other
  vendor/customer list derives from.

  customer_rank / supplier_rank are columns the accounts plugin adds, so those two views are guarded behind Package::isPluginInstalled('accounts').

  Added customers / vendors labels to all five locales (en, ar, es, fr, pt_BR); the employees key was already there.

  Tests: plugins/webkul/partners/tests/Feature/Filament/PartnerTypeViewsTest.php — 7 tests covering each view's query and the view set on both list pages.
  PartnerFeature suite: 81 passed.

  Closes #1489