### PR TITLE
Issue #1502 fixed

### DIFF
--- a/plugins/webkul/support/src/Models/Currency.php
+++ b/plugins/webkul/support/src/Models/Currency.php
@@ -28,6 +28,11 @@ class Currency extends Model
         'active' => 'boolean',
     ];
 
+    public function getCodeAttribute(): ?string
+    {
+        return $this->name;
+    }
+
     public function scopeActive(Builder $query): Builder
     {
         return $query->where('active', true);


### PR DESCRIPTION
currencies has no code column — the ISO code is stored in name (name = 'INR', symbol = '₹', full_name = 'Indian rupee'). Screens that format money split into two conventions: the totals use
  money($amount, $currency->name) and render correctly, while the order lines use ->money(fn ($record) => $record->currency->code). Reading code on the model returns null, and Filament then
  formats with its default currency, so a non-USD order showed ₹100.00 in its totals and $100.00 on every line.

  Adds a code accessor on Currency returning name. That fixes every call site at once — 19 of them across sales, purchases, accounting, and the customer portal — instead of leaving ->code as
  an attribute that silently reads as null wherever someone reaches for it. ShowsCurrencyNotice already wrote $currency?->name ?? $currency?->code, which shows the two spellings were meant to
  be the same thing.

  Fixes #1502