### PR TITLE
Fix EmployeeFactory writing values its columns do not accept

### DIFF
--- a/plugins/webkul/employees/database/factories/EmployeeFactory.php
+++ b/plugins/webkul/employees/database/factories/EmployeeFactory.php
@@ -3,10 +3,14 @@
 namespace Webkul\Employee\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Webkul\Employee\Enums\DistanceUnit;
+use Webkul\Employee\Enums\Gender;
+use Webkul\Employee\Enums\MaritalStatus;
 use Webkul\Employee\Models\Department;
 use Webkul\Employee\Models\DepartureReason;
 use Webkul\Employee\Models\Employee;
 use Webkul\Employee\Models\EmployeeJobPosition;
+use Webkul\Employee\Models\EmploymentType;
 use Webkul\Employee\Models\WorkLocation;
 use Webkul\Security\Models\User;
 use Webkul\Support\Database\Factories\Concerns\HasCompanyDefault;
@@ -57,7 +61,7 @@ class EmployeeFactory extends Factory
             'children'                       => fake()->numberBetween(0, 5),
             'distance_home_work'             => fake()->numberBetween(5, 100),
             'km_home_work'                   => fake()->numberBetween(5, 100),
-            'distance_home_work_unit'        => fake()->randomElement(['km', 'miles']),
+            'distance_home_work_unit'        => fake()->randomElement(DistanceUnit::cases())->value,
             'private_street1'                => fake()->streetAddress,
             'private_street2'                => fake()->secondaryAddress,
             'private_city'                   => fake()->city,
@@ -65,9 +69,9 @@ class EmployeeFactory extends Factory
             'private_phone'                  => fake()->phoneNumber,
             'private_email'                  => fake()->unique()->safeEmail,
             'lang'                           => fake()->languageCode,
-            'gender'                         => fake()->randomElement(),
+            'gender'                         => fake()->randomElement(Gender::cases())->value,
             'birthday'                       => fake()->date(),
-            'marital'                        => fake()->randomElement(['single', 'married', 'divorced', 'widowed']),
+            'marital'                        => fake()->randomElement(MaritalStatus::cases())->value,
             'spouse_complete_name'           => fake()->name,
             'spouse_birthdate'               => fake()->date(),
             'place_of_birth'                 => fake()->city,
@@ -82,7 +86,7 @@ class EmployeeFactory extends Factory
             'study_school'                   => fake()->company,
             'emergency_contact'              => fake()->name,
             'emergency_phone'                => fake()->phoneNumber,
-            'employee_type'                  => fake()->randomElement(['full-time', 'part-time', 'contractor']),
+            'employee_type'                  => EmploymentType::factory(),
             'barcode'                        => fake()->ean13,
             'pin'                            => fake()->randomNumber(6, true),
             'private_car_plate'              => fake()->bothify('??-###-##'),

--- a/plugins/webkul/employees/tests/Feature/Models/EmployeeFactoryTest.php
+++ b/plugins/webkul/employees/tests/Feature/Models/EmployeeFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once __DIR__.'/../../../../support/tests/Helpers/TestBootstrapHelper.php';
+
+use Webkul\Employee\Enums\DistanceUnit;
+use Webkul\Employee\Enums\Gender;
+use Webkul\Employee\Enums\MaritalStatus;
+use Webkul\Employee\Models\Employee;
+
+beforeEach(function () {
+    TestBootstrapHelper::ensurePluginInstalled('employees');
+});
+
+it('builds an employee from its factory', function () {
+    $employee = Employee::factory()->create();
+
+    expect($employee->exists)->toBeTrue()
+        ->and($employee->name)->not->toBeEmpty();
+});
+
+it('only writes values the enum-backed columns accept', function () {
+    $employee = Employee::factory()->create();
+
+    expect(Gender::tryFrom($employee->gender))->not->toBeNull()
+        ->and(DistanceUnit::tryFrom($employee->distance_home_work_unit))->not->toBeNull()
+        ->and(MaritalStatus::tryFrom($employee->marital))->not->toBeNull();
+});
+
+it('resolves the employment type relation', function () {
+    $employee = Employee::factory()->create();
+
+    expect($employee->employmentType)->not->toBeNull()
+        ->and($employee->employmentType->name)->not->toBeEmpty();
+});


### PR DESCRIPTION
Follow-up to #1513 (which closed #1474). That PR fixed the three problems I originally reported, but `EmployeeFactory` still writes three values the application does not accept.

### 1. `gender` produced `'a'`, `'b'` or `'c'`

```php
'gender' => fake()->randomElement(),
```

Faker's signature is `randomElement($array = ['a', 'b', 'c'])`, so calling it with no arguments returns one of those placeholders. `employees_employees.gender` is a plain nullable `string` with no check constraint, so the value persists happily. It only shows up later as an empty `Select` in the employee form, which offers `Gender::options()` (`male` / `female` / `other`).

This is the same class of bug as the `location_type` one #1513 fixed on `WorkLocationFactory`.

### 2. `distance_home_work_unit` used a vocabulary that does not exist

```php
'distance_home_work_unit' => fake()->randomElement(['km', 'miles']),
```

`DistanceUnit` only defines `kilometer` and `meter`, and `EmployeeForm` renders that field with `->options(DistanceUnit::options())`. Neither `'km'` nor `'miles'` matches an option.

### 3. `employee_type` broke the `employmentType` relation

```php
'employee_type' => fake()->randomElement(['full-time', 'part-time', 'contractor']),
```

`Employee::employmentType()` declares `belongsTo(EmploymentType::class, 'employee_type')`, so reading the relation queries `employees_employment_types` for an `id` of `'contractor'`:

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type bigint: "contractor"
(SQL: select * from "employees_employment_types" where "employees_employment_types"."id" = contractor limit 1)
```

PostgreSQL raises that exception; MySQL coerces the string to `0` and quietly returns `null`, which is why it is easy to miss. `EmployeesTable` groups on `employmentType.name` and exposes a `RelationshipConstraint` on `employmentType`, so this is reachable from the UI, not just from tests.

`marital` was already consistent with `MaritalStatus`, but it is now derived from the enum so it cannot drift the same way.

## Why this was not caught

Every existing employees test builds employees through `EmployeeHelper::employee()`, which calls `Employee::create(['name' => ...])` and deliberately bypasses the factory. Nothing in the suite ever executed the broken `definition()`.

This PR adds `EmployeeFactoryTest`, which exercises `Employee::factory()` directly. Run against the previous factory it fails twice:

- `EmployeeFactoryTest.php:24` - `Gender::tryFrom('a')` returns `null`
- `EmployeeFactoryTest.php:32` - reading `employmentType` throws the `QueryException` above

## Testing

`vendor/bin/pest plugins/webkul/employees/tests/` on PostgreSQL: 12 passed, 0 failures.

## Note for maintainers

While tracing #3 I noticed `employees_employees.employee_type` is declared as `string('employee_type')->default('employee')` with no foreign key constraint, even though the model treats it as a foreign key to `employees_employment_types`. I have matched the model's intent here since that is what the UI relies on, but the column type and its `'employee'` default look like they predate the relation. Happy to follow up separately if you would like the schema aligned.
