### PR TITLE
FIX (plugin-manager): force migrate and clear settings cache on plugin…

### DIFF
--- a/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
+++ b/plugins/webkul/plugin-manager/src/Console/Commands/InstallCommand.php
@@ -287,8 +287,11 @@ class InstallCommand extends Command
             $this->info("⚙️ Running <comment>{$this->package->shortName()}</comment> settings database migrations...");
 
             $this->call('migrate', [
-                '--path' => $settingsToRun->toArray(),
+                '--path'  => $settingsToRun->toArray(),
+                '--force' => true,
             ]);
+
+            $this->callSilently('settings:clear-cache');
 
             $this->info("✅ Settings migrations <comment>{$this->package->shortName()}</comment> completed successfully.");
 


### PR DESCRIPTION
### Description
When installing plugins that register Spatie settings (such as `accounts`), accessing views often throws a `Spatie\LaravelSettings\Exceptions\MissingSettings` exception.

### Cause
1. `InstallCommand` executes settings migrations via `artisan migrate`, successfully inserting records into the `settings` table, but does not invalidate the Spatie settings cache afterwards.
2. In production environments, calling `migrate` without `--force` can trigger interactive confirmation prompts, causing migration execution to halt.

### Solution
- Added `--force => true` to the settings migration call to prevent interactive prompt blocks in production.
- Added `$this->callSilently('settings:clear-cache')` immediately after settings migrations run, ensuring the application recognizes the newly inserted settings without requiring manual cache intervention.