### PR TITLE
Require confirmation before deleting a product line in receipts

### DIFF
--- a/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/OperationResource/Schemas/OperationForm.php
+++ b/plugins/webkul/inventories/src/Filament/Clusters/Operations/Resources/OperationResource/Schemas/OperationForm.php
@@ -518,6 +518,7 @@ class OperationForm
                         fn (array $arguments, Get $get): bool => filled($get("moves.{$arguments['item']}.product_id"))
                     ),
             ])
+            ->deleteAction(fn (Action $action) => $action->requiresConfirmation())
             ->deletable(fn ($record): bool => ! in_array($record?->state, [OperationState::DONE, OperationState::CANCELED]))
             ->addable(fn ($record): bool => ! in_array($record?->state, [OperationState::DONE, OperationState::CANCELED]));
     }


### PR DESCRIPTION
## Summary

Fixes #276.

Deleting a product row while creating/editing a Receipt removed it
immediately with no confirmation, so a misclick loses the line with
no way to undo it. The `moves` repeater in `OperationForm` (shared by
Receipts, Deliveries, Internal Transfers and Dropships) was missing
the `requiresConfirmation()` guard on its delete action.

Every other module with the same "line items in a repeater" pattern
already has this guard: sales quotations, purchase orders, bills,
invoices and journal entries all call
`->deleteAction(fn (Action $action) => $action->requiresConfirmation())`
on their repeaters. This applies the same, already-established
pattern to `OperationForm::getMovesRepeater()`.

## Test plan

- [x] `vendor/bin/pint --dirty --format agent` passes on the changed file
- [x] Manually verified in the browser: Inventory → Operations →
      Receipts → Create → add a product line → click the delete
      (trash) icon → a "Delete — Are you sure you would like to do
      this?" modal appears with Cancel/Confirm
  - Cancel closes the modal and keeps the row
  - Confirm removes the row
- [x] Same behavior confirmed on Deliveries and Internal Transfers,
      which share the same `getMovesRepeater()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)